### PR TITLE
Add documentation on forwarding web requests

### DIFF
--- a/source/web-hosting/applications.rst
+++ b/source/web-hosting/applications.rst
@@ -99,7 +99,7 @@ You will need to pick a port (we've used 999 here but you should pick a differen
 Using UNIX sockets
 ^^^^^^^^^^^^^^^^^^
 
-You will need to configure your application to use a UNIX socket and then add the following to your ``.htaccess`` file, replacing as necessary::
+You will need to configure your application to use a UNIX socket. You should make sure the socket is only accessible to you, either by using appropriate file modes or by picking a path that is only accessible to you such as ``/home/crsid/myapp/web.sock``. Then add the following to your ``.htaccess`` file, replacing as necessary::
 
     RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
     RequestHeader set Host expr=%{HTTP_HOST}

--- a/source/web-hosting/applications.rst
+++ b/source/web-hosting/applications.rst
@@ -81,6 +81,26 @@ To install dependencies::
 
 Then see ``nodejs/app.js`` for a minimum base application.
 
+Forwarding requests to your application server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The SRCF uses Apache to serve websites so if you need to forward requests to a backend web app, for example a Django, Rails or Express server, then you will need to forward web requests.
+
+Using TCP ports
+^^^^^^^^^^^^^^^
+
+TODO.
+
+Using UNIX sockets
+^^^^^^^^^^^^^^^^^^
+
+You will need to configure you server application to use a UNIX socket and then add the following to your ``.htaccess`` file, replacing as necessary::
+
+    RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
+    RequestHeader set Host expr=%{HTTP_HOST}
+    RewriteCond %{HTTP_HOST} ^your\.hostname\.tld$
+    RewriteRule ^(.*)$ unix:/home/crsid/myapp/web.sock|http://your.hostname.tld/$1 [P,NE,L]
+
 Static site generators
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/web-hosting/applications.rst
+++ b/source/web-hosting/applications.rst
@@ -91,9 +91,10 @@ Using UNIX sockets
 
 You will need to configure your application to use a UNIX socket. You should make sure the socket is only accessible to you, either by using appropriate file modes or by picking a path that is only accessible to you such as ``/home/crsid/myapp/web.sock``. Then add the following to your ``.htaccess`` file, replacing as necessary::
 
-    RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
     RequestHeader set Host expr=%{HTTP_HOST}
-    RewriteCond %{HTTP_HOST} ^your\.hostname\.tld$
+    RequestHeader set X-Forwarded-For expr=%{REMOTE_ADDR}
+    RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
+    RequestHeader set X-Real-IP expr=%{REMOTE_ADDR}
     RewriteRule ^(.*)$ unix:/home/crsid/myapp/web.sock|http://your.hostname.tld/$1 [P,NE,L,QSA]
 
 Using TCP ports
@@ -101,9 +102,6 @@ Using TCP ports
 
 You will need to pick a port (we've used 999 here but you should pick a different one above 1024) and configure your application to bind to that port. Be aware that port-based forwarding offers less security than UNIX socket-based forwarding and that any other user will be able to forward requests to the same port you are using. For that reason, we don't set the headers we do above as they can easily be forged by another user. Those things being considered, you can put the following in your ``.htaccess`` file to enable forwarding requests to a port::
 
-    RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
-    RequestHeader set Host expr=%{HTTP_HOST}
-    RewriteCond %{HTTP_HOST} ^your\.hostname\.tld$
     RewriteRule "^(.*)$" http://localhost:999/$1 [P,NE,L,QSA]
 
 Static site generators

--- a/source/web-hosting/applications.rst
+++ b/source/web-hosting/applications.rst
@@ -86,16 +86,6 @@ Forwarding requests to your application server
 
 The SRCF uses Apache to serve websites so if you need to run a backend web app, for example a Django, Rails or Express server, then you will need to forward web requests. Make sure you run your application server on ``sinkhole`` rather than ``pip`` or another SRCF server.
 
-Using TCP ports
-^^^^^^^^^^^^^^^
-
-You will need to pick a port (we've used 999 here but you should pick a different one above 1024) and configure your application to bind to that port. Then stick the following in your ``.htaccess`` file::
-
-    RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
-    RequestHeader set Host expr=%{HTTP_HOST}
-    RewriteCond %{HTTP_HOST} ^your\.hostname\.tld$
-    RewriteRule "^(.*)$" http://localhost:999/$1 [P,NE,L,QSA]
-
 Using UNIX sockets
 ^^^^^^^^^^^^^^^^^^
 
@@ -105,6 +95,16 @@ You will need to configure your application to use a UNIX socket. You should mak
     RequestHeader set Host expr=%{HTTP_HOST}
     RewriteCond %{HTTP_HOST} ^your\.hostname\.tld$
     RewriteRule ^(.*)$ unix:/home/crsid/myapp/web.sock|http://your.hostname.tld/$1 [P,NE,L,QSA]
+
+Using TCP ports
+^^^^^^^^^^^^^^^
+
+You will need to pick a port (we've used 999 here but you should pick a different one above 1024) and configure your application to bind to that port. Be aware that port-based forwarding offers less security than UNIX socket-based forwarding and that any other user will be able to forward requests to the same port you are using. For that reason, we don't set the headers we do above as they can easily be forged by another user. Those things being considered, you can put the following in your ``.htaccess`` file to enable forwarding requests to a port::
+
+    RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
+    RequestHeader set Host expr=%{HTTP_HOST}
+    RewriteCond %{HTTP_HOST} ^your\.hostname\.tld$
+    RewriteRule "^(.*)$" http://localhost:999/$1 [P,NE,L,QSA]
 
 Static site generators
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/source/web-hosting/applications.rst
+++ b/source/web-hosting/applications.rst
@@ -84,22 +84,27 @@ Then see ``nodejs/app.js`` for a minimum base application.
 Forwarding requests to your application server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The SRCF uses Apache to serve websites so if you need to forward requests to a backend web app, for example a Django, Rails or Express server, then you will need to forward web requests.
+The SRCF uses Apache to serve websites so if you need to forward requests to a backend web app, for example a Django, Rails or Express server, then you will need to forward web requests. Make sure you run your application server on ``sinkhole`` rather than ``pip`` or another SRCF server.
 
 Using TCP ports
 ^^^^^^^^^^^^^^^
 
-TODO.
-
-Using UNIX sockets
-^^^^^^^^^^^^^^^^^^
-
-You will need to configure you server application to use a UNIX socket and then add the following to your ``.htaccess`` file, replacing as necessary::
+You will need to pick a port (we've used 999 here but you should pick a different one above 1024) and configure your application to bind to that port. Then stick the following in you ``.htaccess`` file::
 
     RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
     RequestHeader set Host expr=%{HTTP_HOST}
     RewriteCond %{HTTP_HOST} ^your\.hostname\.tld$
-    RewriteRule ^(.*)$ unix:/home/crsid/myapp/web.sock|http://your.hostname.tld/$1 [P,NE,L]
+    RewriteRule "^(.*)$" http://localhost:999/$1 [P,NE,L,QSA]
+
+Using UNIX sockets
+^^^^^^^^^^^^^^^^^^
+
+You will need to configure your application to use a UNIX socket and then add the following to your ``.htaccess`` file, replacing as necessary::
+
+    RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
+    RequestHeader set Host expr=%{HTTP_HOST}
+    RewriteCond %{HTTP_HOST} ^your\.hostname\.tld$
+    RewriteRule ^(.*)$ unix:/home/crsid/myapp/web.sock|http://your.hostname.tld/$1 [P,NE,L,QSA]
 
 Static site generators
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/source/web-hosting/applications.rst
+++ b/source/web-hosting/applications.rst
@@ -84,12 +84,12 @@ Then see ``nodejs/app.js`` for a minimum base application.
 Forwarding requests to your application server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The SRCF uses Apache to serve websites so if you need to forward requests to a backend web app, for example a Django, Rails or Express server, then you will need to forward web requests. Make sure you run your application server on ``sinkhole`` rather than ``pip`` or another SRCF server.
+The SRCF uses Apache to serve websites so if you need to run a backend web app, for example a Django, Rails or Express server, then you will need to forward web requests. Make sure you run your application server on ``sinkhole`` rather than ``pip`` or another SRCF server.
 
 Using TCP ports
 ^^^^^^^^^^^^^^^
 
-You will need to pick a port (we've used 999 here but you should pick a different one above 1024) and configure your application to bind to that port. Then stick the following in you ``.htaccess`` file::
+You will need to pick a port (we've used 999 here but you should pick a different one above 1024) and configure your application to bind to that port. Then stick the following in your ``.htaccess`` file::
 
     RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
     RequestHeader set Host expr=%{HTTP_HOST}


### PR DESCRIPTION
This PR adds documentation on the procedure to forward web requests from Apache to another web application server using either:

- [x] TCP ports
- [x] UNIX sockets

This is currently a WIP.