### PR TITLE
change pip to pip3

### DIFF
--- a/source/learn/tutorials/deploy-python.rst
+++ b/source/learn/tutorials/deploy-python.rst
@@ -67,7 +67,7 @@ There is a demo flask app setup at https://sample.soc.srcf.net/flask/. See ``fla
 Installing gunicorn
 ^^^^^^^^^^^^^^^^^^^
 
-We recommend using gunicorn to serve your application. After activating your virtualenv, install it with ``pip install gunicorn``.
+We recommend using gunicorn to serve your application. After activating your virtualenv, install it with ``pip3 install gunicorn``.
 
 Note that you may see a warning about a syntax error. As long as the output ends in "Successfully installed gunicorn", `it's safe to ignore this <https://stackoverflow.com/a/25611194>`__.
 


### PR DESCRIPTION
I tried to use `pip install gunicorn`, but that was using the 2.7 version of Python. `pip3 install gunicorn` seemed to work:
![image](https://user-images.githubusercontent.com/20886570/91502383-33e57380-e8c8-11ea-9ae8-17186fa97310.png)