### PR TITLE
Tidy up code snippets

### DIFF
--- a/content/guides/getting-started-groups.md
+++ b/content/guides/getting-started-groups.md
@@ -20,18 +20,18 @@ Even as a society webmaster, or someone looking to setup a website for a group, 
 In your home directory, a shortcut (symbolic link) to your group's file space is automatically created, and in it is the `public_html` you will want. This is also a shortcut to your group's *public* file space, which contains the actual `public_html` directory. Here is a useful breakdown that also includes the absolute file paths:
 
 ```bash
-    spqr2@pip:~$ ls -l
-    mysociety1 -> /societies/mysociety1
-    mysociety2 -> /societies/mysociety2
-    public_html -> /public/home/spqr2/public_html
+spqr2@pip:~$ ls -l
+mysociety1 -> /societies/mysociety1
+mysociety2 -> /societies/mysociety2
+public_html -> /public/home/spqr2/public_html
 ```
 
 ```bash
-    spqr2@pip:~$ cd mysociety1
-    spqr2@pip:~$ pwd -P
-    /societies/mysociety1
-    spqr2@pip:~$ ls -l
-    public_html -> /public/societies/mysociety1
+spqr2@pip:~$ cd mysociety1
+spqr2@pip:~$ pwd -P
+/societies/mysociety1
+spqr2@pip:~$ ls -l
+public_html -> /public/societies/mysociety1
 ```
 
 ## Your options

--- a/content/guides/getting-started-groups.md
+++ b/content/guides/getting-started-groups.md
@@ -19,14 +19,14 @@ Even as a society webmaster, or someone looking to setup a website for a group, 
 
 In your home directory, a shortcut (symbolic link) to your group's file space is automatically created, and in it is the `public_html` you will want. This is also a shortcut to your group's *public* file space, which contains the actual `public_html` directory. Here is a useful breakdown that also includes the absolute file paths:
 
-```bash
+```text
 spqr2@pip:~$ ls -l
 mysociety1 -> /societies/mysociety1
 mysociety2 -> /societies/mysociety2
 public_html -> /public/home/spqr2/public_html
 ```
 
-```bash
+```text
 spqr2@pip:~$ cd mysociety1
 spqr2@pip:~$ pwd -P
 /societies/mysociety1

--- a/content/guides/getting-started-users.md
+++ b/content/guides/getting-started-users.md
@@ -34,15 +34,15 @@ If you are not familiar with HTML and CSS and how websites work, then don't fret
 {{< /alert >}}
 
 ```html
-    <!DOCTYPE html>
-    <html lang="en">
-        <meta charset="UTF-8">
-        <title>I love the SRCF</title>
-        <meta name="viewport" content="width=device-width,initial-scale=1">
-        <body>
-            <h1>Hello there!</h1>
-        </body>
-    </html> 
+<!DOCTYPE html>
+<html lang="en">
+    <meta charset="UTF-8">
+    <title>I love the SRCF</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <body>
+        <h1>Hello there!</h1>
+    </body>
+</html>
 ```
 
 Now press "ctrl-o" then enter to confirm the file name, followed by "ctrl-x" to exit the editor. You should now be able to see a "Hello there!" on your SRCF domain.

--- a/content/guides/upgrade-guidance/sinkhole.md
+++ b/content/guides/upgrade-guidance/sinkhole.md
@@ -62,17 +62,17 @@ remaining methods.
 Sample MySQL library code:
 
 ```php
-    mysql_connect("localhost", "<user>", "<password>");
-    $result = mysql_query("...");
-    while ($row = mysql_fetch_assoc($result)) { ... }
+mysql_connect("localhost", "<user>", "<password>");
+$result = mysql_query("...");
+while ($row = mysql_fetch_assoc($result)) { ... }
 ```
 
 Equivalent MySQLi code:
 
 ```php
-    $conn = mysqli_connect("localhost", "<user>", "<password>");
-    $result = mysqli_query($conn, "...");
-    while ($row = mysqli_fetch_assoc($result)) { ... }
+$conn = mysqli_connect("localhost", "<user>", "<password>");
+$result = mysqli_query($conn, "...");
+while ($row = mysqli_fetch_assoc($result)) { ... }
 ```
 
 ### ucam-webauth-php
@@ -81,7 +81,7 @@ Versions prior to 0.53 include a function call with an argument ignored
 in PHP 5.x but removed in 7.x. Error logs will contain something like:
 
 ```php
-    PHP Warning:  gmmktime() expects at most 6 parameters, 7 given in .../ucam_webauth.php on line 388
+PHP Warning:  gmmktime() expects at most 6 parameters, 7 given in .../ucam_webauth.php on line 388
 ```
 
 The latest version can be obtained from
@@ -96,13 +96,13 @@ htaccess.
 Example php\_override.ini setting:
 
 ```ini
-    key = value
+key = value
 ```
 
 Equivalent htaccess setting:
 
 ```ini
-    php_value key value
+php_value key value
 ```
 
 ## PostgreSQL

--- a/content/guides/upgrade-guidance/wordpress.md
+++ b/content/guides/upgrade-guidance/wordpress.md
@@ -33,14 +33,14 @@ configuration (wp-config.php), near the bottom but above the line that
 says \"stop editing\":
 
 ```php
-    /**
-    * Force wordpress to use direct filesystem access so that upgrades work
-    * properly. See: https://core.trac.wordpress.org/ticket/10205
-    * https://codex.wordpress.org/Editing_wp-config.php
-    */
-    define('FS_METHOD', 'direct');
-    define('FS_CHMOD_DIR', (02775 & ~ umask()));
-    define('FS_CHMOD_FILE', (0664 & ~ umask()));
+/**
+* Force wordpress to use direct filesystem access so that upgrades work
+* properly. See: https://core.trac.wordpress.org/ticket/10205
+* https://codex.wordpress.org/Editing_wp-config.php
+*/
+define('FS_METHOD', 'direct');
+define('FS_CHMOD_DIR', (02775 & ~ umask()));
+define('FS_CHMOD_FILE', (0664 & ~ umask()));
 ```
 
 **You must ensure all WordPress files have the correct group

--- a/content/internal/documentation/how-it-works.md
+++ b/content/internal/documentation/how-it-works.md
@@ -29,31 +29,31 @@ An important step to the second iteration of our documentation was addressing di
 It helps to be familiar with Hugo's directory structure, but the two main folders of interest are `content` and `layouts`, seen below.  
 
 ```bash
-    docs
-    ┣ archetypes
-    ┣ content
-    ┃ ┣ guides
-    ┃ ┣ internal
-    ┃ ┃ ┣ documentation
-    ┃ ┃ ┃ ┗ updating-a-page.md
-    ┃ ┃ ┗ _index.md
-    ┃ ┣ reference
-    ┃ ┣ tutorials
-    ┃ ┗ _index.md
-    ┣ data
-    ┃ ┗ sidebar.yaml
-    ┣ layouts
-    ┃ ┣ _default
-    ┃ ┣ partials
-    ┃ ┣ shortcodes
-    ┃ ┗ index.html
-    ┣ resources
-    ┣ static
-    ┃ ┣ css
-    ┃ ┃ ┗ style.css
-    ┃ ┣ vendor
-    ┃ ┗ .htaccess
-    ┗ config.toml
+docs
+┣ archetypes
+┣ content
+┃ ┣ guides
+┃ ┣ internal
+┃ ┃ ┣ documentation
+┃ ┃ ┃ ┗ updating-a-page.md
+┃ ┃ ┗ _index.md
+┃ ┣ reference
+┃ ┣ tutorials
+┃ ┗ _index.md
+┣ data
+┃ ┗ sidebar.yaml
+┣ layouts
+┃ ┣ _default
+┃ ┣ partials
+┃ ┣ shortcodes
+┃ ┗ index.html
+┣ resources
+┣ static
+┃ ┣ css
+┃ ┃ ┗ style.css
+┃ ┣ vendor
+┃ ┗ .htaccess
+┗ config.toml
 ```
 
 An overview of the purpose of all folders and files:
@@ -63,7 +63,7 @@ An overview of the purpose of all folders and files:
     An archetype is essentially a template for a new section entry, like `reference`, `tutorials`, and other root-level dirs below `content`. Hugo looks in this folder when using the `hugo new` command like so:
 
     ```bash
-        hugo new internal/documentation/another-page.md
+    hugo new internal/documentation/another-page.md
     ```
 
     and creates an empty page with the pre-filled boilerplate in the archetype.
@@ -93,18 +93,18 @@ Content is grouped in the sidebar according to its `group` property. Sidebar log
 The sidebar sources its text from a `yaml` data file in the `data` folder. At a glance, this file has a top-level list of category objects.
 
 ```yaml
-    # category object
-    - category: Internal 
-      # list of groups
-      groups:
-        # a group called "documentation"
-        - title: Documentation
-          # pages under this group
-          pages:
-            - title: How it works
-            - title: Building
-            - title: Managing content
-            - title: Reference
+# category object
+- category: Internal
+  # list of groups
+  groups:
+    # a group called "documentation"
+    - title: Documentation
+      # pages under this group
+      pages:
+        - title: How it works
+        - title: Building
+        - title: Managing content
+        - title: Reference
 ```
 
 Each category object has a name, which must correspond to the Hugo section name (when urlized), eg. "tutorials", "reference", essentially the name of the folder.

--- a/content/internal/documentation/reference.md
+++ b/content/internal/documentation/reference.md
@@ -16,10 +16,10 @@ Pre-defined bits of HTML that the user can easily inject into the Markdown.
 
 ### Alert
 
-```Go
-    {{</* alert type="info" */>}}
-        some content in here
-    {{</*  /alert */>}}
+```Markdown
+{{</* alert type="info" */>}}
+    some content in here
+{{</*  /alert */>}}
 ```
 
 `type` can be any valid Bootstrap [alert type](https://getbootstrap.com/docs/5.0/components/alerts/). The above produces
@@ -36,12 +36,12 @@ Shortcode borrowed from [here](https://willschenk.com/articles/2020/styling_tabl
 
 Example:
 
-```Go
-    {{</* table “table table-striped table-bordered" */>}}
-    |———-|———-|———-|
-    | Item 1   | Item 2   | Item 3   |
-    | Item 1a  | Item 2a  | Item 3a  |
-    {{</* /table */ >}}
+```Markdown
+{{</* table “table table-striped table-bordered" */>}}
+|———-|———-|———-|
+| Item 1   | Item 2   | Item 3   |
+| Item 1a  | Item 2a  | Item 3a  |
+{{</* /table */ >}}
 ```
 
 ## Front matter params
@@ -64,7 +64,7 @@ A quick glance at the structure of the `yaml` file should reveal most of the com
 Use a regular Markdown link but with the `relref` shortcode as such:
 
 ```Markdown
-    [mail forwarding]({{</* relref "#mail-forwarding" */>}})
+[mail forwarding]({{</* relref "#mail-forwarding" */>}})
 ```
 
 ### Syntax highlighting

--- a/content/internal/documentation/reference.md
+++ b/content/internal/documentation/reference.md
@@ -16,7 +16,7 @@ Pre-defined bits of HTML that the user can easily inject into the Markdown.
 
 ### Alert
 
-```Markdown
+```go-text-template
 {{</* alert type="info" */>}}
     some content in here
 {{</*  /alert */>}}
@@ -36,7 +36,7 @@ Shortcode borrowed from [here](https://willschenk.com/articles/2020/styling_tabl
 
 Example:
 
-```Markdown
+```go-text-template
 {{</* table “table table-striped table-bordered" */>}}
 |———-|———-|———-|
 | Item 1   | Item 2   | Item 3   |

--- a/content/reference/common-requests.md
+++ b/content/reference/common-requests.md
@@ -50,8 +50,8 @@ tool over SSH, which can fix your own files and those of the group
 account:
 
 ```bash
-$ srcf-soc-permfix <groupname>
-$ sudo -u <groupname> srcf-soc-permfix <groupname>
+srcf-soc-permfix <groupname>
+sudo -u <groupname> srcf-soc-permfix <groupname>
 ```
 
 However, this won't be able to fix files owned by other admins. If you

--- a/content/reference/common-requests.md
+++ b/content/reference/common-requests.md
@@ -50,8 +50,8 @@ tool over SSH, which can fix your own files and those of the group
 account:
 
 ```bash
-    $ srcf-soc-permfix <groupname>
-    $ sudo -u <groupname> srcf-soc-permfix <groupname>
+$ srcf-soc-permfix <groupname>
+$ sudo -u <groupname> srcf-soc-permfix <groupname>
 ```
 
 However, this won't be able to fix files owned by other admins. If you

--- a/content/reference/email/legacy-mail-on-pip.md
+++ b/content/reference/email/legacy-mail-on-pip.md
@@ -87,21 +87,21 @@ addresses with a simpler syntax. You need to create a file called
 for your own roles), where each line consists of a role name, a colon,
 and a comma-separated list of target addresses:
 
-```
-    <role>:<email>,<email>...
+```text
+<role>:<email>,<email>...
 ```
 
 For example:
 
-```
-    treasurer:spqr2@cam.ac.uk,treasurer@example.com
+```text
+treasurer:spqr2@cam.ac.uk,treasurer@example.com
 ```
 
 Once you've defined your roles, you need to build the actual `.forward`
 file:
 
-```
-    srcf-autoforward <groupname>
+```bash
+srcf-autoforward <groupname>
 ```
 
 ## Mail filtering
@@ -118,24 +118,24 @@ your email into a custom program.
 Here are a few examples of basic forwarding for a group account. Note
 that the `# Exim filter` line is required.
 
-```exim
-    # Exim filter
+```text
+# Exim filter
 
-    # Forward emails for <groupname>-webmaster@srcf.net to spqr2@cam.ac.uk:
-    if ($local_part_suffix is "-webmaster") then
-       deliver spqr2@cam.ac.uk
-    endif
+# Forward emails for <groupname>-webmaster@srcf.net to spqr2@cam.ac.uk:
+if ($local_part_suffix is "-webmaster") then
+   deliver spqr2@cam.ac.uk
+endif
 
-    # Forward <groupname>-treasurer@srcf.net to spqr and an external address:
-    if ($local_part_suffix is "-treasurer") then
-       deliver spqr2@cam.ac.uk
-       deliver treasurer@example.com
-    endif
+# Forward <groupname>-treasurer@srcf.net to spqr and an external address:
+if ($local_part_suffix is "-treasurer") then
+   deliver spqr2@cam.ac.uk
+   deliver treasurer@example.com
+endif
 
-    # Forward anything not yet processed to a lists.cam mailing list:
-    if not delivered then
-       deliver group-example-committee@lists.cam.ac.uk
-    endif
+# Forward anything not yet processed to a lists.cam mailing list:
+if not delivered then
+   deliver group-example-committee@lists.cam.ac.uk
+endif
 ```
 
 ## Known quirks

--- a/content/reference/group-accounts/files-and-permissions.md
+++ b/content/reference/group-accounts/files-and-permissions.md
@@ -21,9 +21,9 @@ permissions should include group-write. Directories should also be
 group-sticky, so that subdirectories will inherit the correct
 permissions. Example output from `ls -l`:
 
-```bash
-    drwxrwsr-x  2 <crsid> <groupname> 4.0K Jan  1  2020 directory
-    -rw-rw-r--  2 <crsid> <groupname>    0 Jan  1  2020 file
+```text
+drwxrwsr-x  2 <crsid> <groupname> 4.0K Jan  1  2020 directory
+-rw-rw-r--  2 <crsid> <groupname>    0 Jan  1  2020 file
 ```
 
 The important fields to note here are `rw` appearing in both of the

--- a/content/reference/other-services/game-servers.md
+++ b/content/reference/other-services/game-servers.md
@@ -18,7 +18,7 @@ Please limit your server to around 1GB of RAM and set it to `nice` level
 running a Minecraft server, then the following should work:
 
 ```bash
-    nice -n 19 java -Xms1024m -Xmx1024m -jar minecraft_server.jar
+nice -n 19 java -Xms1024m -Xmx1024m -jar minecraft_server.jar
 ```
 
 It is possible (and probable, in the case of Minecraft) that the default

--- a/content/reference/other-services/sql-databases.md
+++ b/content/reference/other-services/sql-databases.md
@@ -27,7 +27,7 @@ which are valid across all user-accessible servers.
 To connect to MySQL from an SRCF shell:
 
 ```bash
-    mysql -h mysql -p <database>
+mysql -h mysql -p <database>
 ```
 
 Here, `-h` specifies the hostname, `-p` prompts for your password, and
@@ -37,7 +37,7 @@ CRSid for your personal database, or a group database name.
 Similarly for PostgreSQL:
 
 ```bash
-    psql -h postgres [database]
+psql -h postgres [database]
 ```
 
 Providing a database is optional; by default, you'll be connected to

--- a/content/reference/shell-and-files/files.md
+++ b/content/reference/shell-and-files/files.md
@@ -106,50 +106,50 @@ directory `.snapshot`, available at any level of the file hierarchy. For
 example:
 
 ```bash
-    spqr2@pip:~$ ls -lut .snapshot
-    total 336
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 18:00 sv_hourly.0
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 17:00 sv_hourly.1
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 16:00 sv_hourly.2
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 15:00 sv_hourly.3
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 14:00 sv_hourly.4
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 13:00 sv_hourly.5
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 12:00 sv_hourly.6
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 11:00 sv_hourly.7
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 10:00 sv_hourly.8
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 09:00 sv_hourly.9
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 08:00 sv_hourly.10
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 07:00 sv_hourly.11
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 06:00 sv_hourly.12
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 05:00 sv_hourly.13
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 04:00 sv_hourly.14
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 03:00 sv_hourly.15
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 02:00 sv_hourly.16
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 01:00 sv_hourly.17
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 01:00 sv_daily.0
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 00:00 sv_hourly.18
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  5 23:00 sv_hourly.19
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  5 22:00 sv_hourly.20
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  5 21:00 sv_hourly.21
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  5 20:00 sv_hourly.22
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  5 19:00 sv_hourly.23
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  5 01:00 sv_daily.1
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  4 01:00 sv_weekly.0
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  4 01:00 sv_daily.2
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  3 01:00 sv_daily.3
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  2 01:00 sv_daily.4
-    drwxr-x--- 2 spqr2 spqr2 8192 Jul  1 01:00 sv_daily.5
-    drwxr-x--- 2 spqr2 spqr2 8192 Jun  2 01:00 sv_daily.6
-    drwxr-x--- 2 spqr2 spqr2 8192 Jun 29 01:00 sv_daily.7
-    drwxr-x--- 2 spqr2 spqr2 8192 Jun 28 01:00 sv_daily.8
-    drwxr-x--- 2 spqr2 spqr2 8192 Jun 27 01:00 sv_weekly.1
-    drwxr-x--- 2 spqr2 spqr2 8192 Jun 27 01:00 sv_daily.9
-    drwxr-x--- 2 spqr2 spqr2 8192 Jun 26 01:00 sv_daily.10
-    drwxr-x--- 2 spqr2 spqr2 8192 Jun 25 01:00 sv_daily.11
-    drwxr-x--- 2 spqr2 spqr2 8192 Jun 24 01:00 sv_daily.12
-    drwxr-x--- 2 spqr2 spqr2 8192 Jun 23 01:00 sv_daily.13
-    drwxr-x--- 2 spqr2 spqr2 8192 Jun 20 01:00 sv_weekly.2
-    drwxr-x--- 2 spqr2 spqr2 8192 Jun 13 01:00 sv_weekly.3
+spqr2@pip:~$ ls -lut .snapshot
+total 336
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 18:00 sv_hourly.0
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 17:00 sv_hourly.1
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 16:00 sv_hourly.2
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 15:00 sv_hourly.3
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 14:00 sv_hourly.4
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 13:00 sv_hourly.5
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 12:00 sv_hourly.6
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 11:00 sv_hourly.7
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 10:00 sv_hourly.8
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 09:00 sv_hourly.9
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 08:00 sv_hourly.10
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 07:00 sv_hourly.11
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 06:00 sv_hourly.12
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 05:00 sv_hourly.13
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 04:00 sv_hourly.14
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 03:00 sv_hourly.15
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 02:00 sv_hourly.16
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 01:00 sv_hourly.17
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 01:00 sv_daily.0
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 00:00 sv_hourly.18
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  5 23:00 sv_hourly.19
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  5 22:00 sv_hourly.20
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  5 21:00 sv_hourly.21
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  5 20:00 sv_hourly.22
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  5 19:00 sv_hourly.23
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  5 01:00 sv_daily.1
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  4 01:00 sv_weekly.0
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  4 01:00 sv_daily.2
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  3 01:00 sv_daily.3
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  2 01:00 sv_daily.4
+drwxr-x--- 2 spqr2 spqr2 8192 Jul  1 01:00 sv_daily.5
+drwxr-x--- 2 spqr2 spqr2 8192 Jun  2 01:00 sv_daily.6
+drwxr-x--- 2 spqr2 spqr2 8192 Jun 29 01:00 sv_daily.7
+drwxr-x--- 2 spqr2 spqr2 8192 Jun 28 01:00 sv_daily.8
+drwxr-x--- 2 spqr2 spqr2 8192 Jun 27 01:00 sv_weekly.1
+drwxr-x--- 2 spqr2 spqr2 8192 Jun 27 01:00 sv_daily.9
+drwxr-x--- 2 spqr2 spqr2 8192 Jun 26 01:00 sv_daily.10
+drwxr-x--- 2 spqr2 spqr2 8192 Jun 25 01:00 sv_daily.11
+drwxr-x--- 2 spqr2 spqr2 8192 Jun 24 01:00 sv_daily.12
+drwxr-x--- 2 spqr2 spqr2 8192 Jun 23 01:00 sv_daily.13
+drwxr-x--- 2 spqr2 spqr2 8192 Jun 20 01:00 sv_weekly.2
+drwxr-x--- 2 spqr2 spqr2 8192 Jun 13 01:00 sv_weekly.3
 ```
 
 Note that snapshots are named `sv_[type].[index]`, with index 0

--- a/content/reference/shell-and-files/files.md
+++ b/content/reference/shell-and-files/files.md
@@ -105,7 +105,7 @@ using the hidden (it will not show up in ls -a or in shell autocomplete)
 directory `.snapshot`, available at any level of the file hierarchy. For
 example:
 
-```bash
+```text
 spqr2@pip:~$ ls -lut .snapshot
 total 336
 drwxr-x--- 2 spqr2 spqr2 8192 Jul  6 18:00 sv_hourly.0

--- a/content/reference/shell-and-files/scheduled-tasks.md
+++ b/content/reference/shell-and-files/scheduled-tasks.md
@@ -132,7 +132,7 @@ sudo -Hu foosoc XDG_RUNTIME_DIR=/run/user/$(id -u foosoc) systemctl --user ...
 You might like to add a function to your `~/.bashrc` to make this easier
 to remember:
 
-```bash
+```sh
 socsudo () {
     soc=$1
     shift

--- a/content/reference/shell-and-files/scheduled-tasks.md
+++ b/content/reference/shell-and-files/scheduled-tasks.md
@@ -20,12 +20,12 @@ Connect over SSH and run `crontab -e`, which will open an editor and an
 explanation of the file format. You can add entries to run something at
 a fixed interval, or on server reboot:
 
-```bash
-    # Run at 03:21 every day:
-    21 3 * * * /home/<crsid>/daily.sh
+```text
+# Run at 03:21 every day:
+21 3 * * * /home/<crsid>/daily.sh
 
-    # Run at server startup:
-    @reboot /home/<crsid>/startup.sh
+# Run at server startup:
+@reboot /home/<crsid>/startup.sh
 ```
 
 If you want to setup cron jobs for a group or society account then
@@ -45,16 +45,16 @@ A sample personal account unit file, `porridge.service`, might look like
 the following:
 
 ```ini
-    [Unit]
-    Description=spqr2 Porridge app
-    ConditionHost=pip
+[Unit]
+Description=spqr2 Porridge app
+ConditionHost=pip
 
-    [Install]
-    WantedBy=default.target
+[Install]
+WantedBy=default.target
 
-    [Service]
-    ExecStart=/home/spqr2/porridge/run.sh
-    Restart=on-failure
+[Service]
+ExecStart=/home/spqr2/porridge/run.sh
+Restart=on-failure
 ```
 
 `ExecStart` defines the command to be run. For group account services,
@@ -90,15 +90,15 @@ your program at system startup. To schedule execution, drop the
 corresponding timer file `porridge.timer`:
 
 ```ini
-    [Unit]
-    Description=spqr2 Porridge daily update
-    ConditionHost=pip
+[Unit]
+Description=spqr2 Porridge daily update
+ConditionHost=pip
 
-    [Install]
-    WantedBy=timers.target
+[Install]
+WantedBy=timers.target
 
-    [Timer]
-    OnCalendar=daily
+[Timer]
+OnCalendar=daily
 ```
 
 This will execute your program at midnight each day. The `OnCalendar`
@@ -125,7 +125,7 @@ when interacting with a group account's services (here using `foosoc`
 for the account name):
 
 ```bash
-    sudo -Hu foosoc XDG_RUNTIME_DIR=/run/user/$(id -u foosoc) systemctl --user ...
+sudo -Hu foosoc XDG_RUNTIME_DIR=/run/user/$(id -u foosoc) systemctl --user ...
 ```
 
 {{< alert type="info" >}}
@@ -133,11 +133,11 @@ You might like to add a function to your `~/.bashrc` to make this easier
 to remember:
 
 ```bash
-    socsudo () {
-
-    soc=\$1 shift sudo -Hu \$soc XDG\_RUNTIME\_DIR=/run/user/\$(id -u
-        \$soc) '\$@'
-    }
+socsudo () {
+    soc=$1
+    shift
+    sudo -Hu soc XDG_RUNTIME_DIR=/run/user/$(id -u $soc) '$@'
+}
 ```
 
 {{< /alert >}}
@@ -148,7 +148,7 @@ If you receive an error like this setting up your group account's first
 service:
 
 ```text
-    Failed to connect to bus: No such file or directory
+Failed to connect to bus: No such file or directory
 ```
 
 ...then you may need to wait up to 20 minutes for lingering to be

--- a/content/reference/shell-and-files/scheduled-tasks.md
+++ b/content/reference/shell-and-files/scheduled-tasks.md
@@ -136,7 +136,7 @@ to remember:
 socsudo () {
     soc=$1
     shift
-    sudo -Hu soc XDG_RUNTIME_DIR=/run/user/$(id -u $soc) '$@'
+    sudo -Hu $soc XDG_RUNTIME_DIR=/run/user/$(id -u $soc) "$@"
 }
 ```
 

--- a/content/reference/web-hosting/cgi-and-php-scripts.md
+++ b/content/reference/web-hosting/cgi-and-php-scripts.md
@@ -53,8 +53,8 @@ For personal users, CGI scripts must be readable and executable by you,
 and must be owned by you. PHP scripts must be world-readable (but to
 keep database passwords secret, see the next question). For example:
 
-```bash
-pip$ ls -l
+```text
+spqr2@pip$ ls -l
 -rwx------  1 saw27  saw27  238 May  5 19:33 env.cgi
 -rw-r--r--  1 saw27  saw27  265 May 13 19:34 phptest.php
 ```
@@ -65,8 +65,8 @@ must be system group readable and executable. Group account PHP scripts
 must additionally be world readable (but to keep database passwords
 secret, see the next question). For example:
 
-```bash
-pip$ ls -l
+```text
+spqr2@pip$ ls -l
 -rwxrwx--- 1 saw27  casi  238 May  7 23:49 env.cgi
 -rw-rw-r-- 1 saw27  casi  265 May 14 23:06 phptest.php
 ```

--- a/content/reference/web-hosting/cgi-and-php-scripts.md
+++ b/content/reference/web-hosting/cgi-and-php-scripts.md
@@ -54,9 +54,9 @@ and must be owned by you. PHP scripts must be world-readable (but to
 keep database passwords secret, see the next question). For example:
 
 ```bash
-    pip$ ls -l
-    -rwx------  1 saw27  saw27  238 May  5 19:33 env.cgi
-    -rw-r--r--  1 saw27  saw27  265 May 13 19:34 phptest.php
+pip$ ls -l
+-rwx------  1 saw27  saw27  238 May  5 19:33 env.cgi
+-rw-r--r--  1 saw27  saw27  265 May 13 19:34 phptest.php
 ```
 
 CGI scripts and PHP scripts belonging to a group account must have their
@@ -66,9 +66,9 @@ must additionally be world readable (but to keep database passwords
 secret, see the next question). For example:
 
 ```bash
-    pip$ ls -l
-    -rwxrwx--- 1 saw27  casi  238 May  7 23:49 env.cgi
-    -rw-rw-r-- 1 saw27  casi  265 May 14 23:06 phptest.php
+pip$ ls -l
+-rwxrwx--- 1 saw27  casi  238 May  7 23:49 env.cgi
+-rw-rw-r-- 1 saw27  casi  265 May 14 23:06 phptest.php
 ```
 
 We recommend that you ensure that group account files are
@@ -103,8 +103,8 @@ even if you just wanted to download them. The following will turn off
 CGI handling for Python scripts, displaying them as plain text instead:
 
 ```apache
-    AddHandler default-handler .py
-    AddType text/plain .py
+AddHandler default-handler .py
+AddType text/plain .py
 ```
 
 Put those lines in a `.htaccess` file in the same directory as your

--- a/content/reference/web-hosting/raven-authentication.md
+++ b/content/reference/web-hosting/raven-authentication.md
@@ -25,62 +25,62 @@ To protect a directory (whether `public_html` for your entire site, or a
 subdirectory of it), create or edit a `.htaccess` file in that
 directory, and add the following:
 
-```
-    AuthType Ucam-WebAuth
-    Require valid-user
+```apache
+AuthType Ucam-WebAuth
+Require valid-user
 ```
 
 This will permit access to anyone with a 'current' Raven account, i.e.
 active students and staff. To permit access to *any* Raven account
 (including graduated students), add a *Ptags* directive:
 
-```
-    AARequiredPtags none
+```apache
+AARequiredPtags none
 ```
 
 Alternatively, you may want to limit access to Raven-authenticated users
 or visitors within the cam.ac.uk domain:
 
-```
-    Order allow,deny
-    Allow from .cam.ac.uk
-    AuthType Ucam-WebAuth
-    Require valid-user
-    Satisfy any
+```apache
+Order allow,deny
+Allow from .cam.ac.uk
+AuthType Ucam-WebAuth
+Require valid-user
+Satisfy any
 ```
 
 To limit page access to group account admins only, add a `unix-group`
 *Require* directive:
 
-```
-    Require unix-group <groupname>
+```apache
+Require unix-group <groupname>
 ```
 
 You can also list specific users:
 
-```
-    Require user <crsid> <crsid>...
+```apache
+Require user <crsid> <crsid>...
 ```
 
 To create a 'logout' link, add the following to your .htaccess file
 (which will create `/logout` relative to the directory containing the
 `.htaccess` file):
 
-```
-    <FilesMatch "logout">
-        SetHandler AALogout
-    </FilesMatch>
+```apache
+<FilesMatch "logout">
+    SetHandler AALogout
+</FilesMatch>
 ```
 
 ### Example configuration:
 
-```
-    RewriteEngine On
-    RewriteCond %{HTTPS} off
-    RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=permanent]
+```apache
+RewriteEngine On
+RewriteCond %{HTTPS} off
+RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=permanent]
 
-    AuthType Ucam-WebAuth
-    Require user CRSID
+AuthType Ucam-WebAuth
+Require user CRSID
 ```
 
 Replace CRSID with your CRSID.

--- a/content/reference/web-hosting/regular-hosting.md
+++ b/content/reference/web-hosting/regular-hosting.md
@@ -41,26 +41,26 @@ output into your account's `public_html` directory.
 To create the skeleton project:
 
 ```bash
-    jekyll new jekyll
-    cd jekyll
+jekyll new jekyll
+cd jekyll
 ```
 
 For a root site (i.e. top of public\_html):
 
 ```bash
-    ln -s /public/societies/sample/public_html _site
+ln -s /public/societies/sample/public_html _site
 ```
 
 ..or for a site in a subdirectory, edit `_config.yaml` to set
 `baseurl` to e.g. `/jekyll`, then:
 
 ```bash
-    mkdir /public/societies/sample/public_html/jekyll
-    ln -s /public/societies/sample/public_html/jekyll _site
+mkdir /public/societies/sample/public_html/jekyll
+ln -s /public/societies/sample/public_html/jekyll _site
 ```
 
 To (re)build the site:
 
 ```bash
-    jekyll build
+jekyll build
 ```

--- a/content/reference/web-hosting/web-applications.md
+++ b/content/reference/web-hosting/web-applications.md
@@ -62,11 +62,11 @@ Then add the following to your `.htaccess` file, replacing
 `ab123.user.srcf.net`) :
 
 ```ApacheConf
-    RequestHeader set Host expr=%{HTTP_HOST}
-    RequestHeader set X-Forwarded-For expr=%{REMOTE_ADDR}
-    RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
-    RequestHeader set X-Real-IP expr=%{REMOTE_ADDR}
-    RewriteRule ^(.*)$ unix:<path-to-socket>|http://<url>/$1 [P,NE,L,QSA]
+RequestHeader set Host expr=%{HTTP_HOST}
+RequestHeader set X-Forwarded-For expr=%{REMOTE_ADDR}
+RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
+RequestHeader set X-Real-IP expr=%{REMOTE_ADDR}
+RewriteRule ^(.*)$ unix:<path-to-socket>|http://<url>/$1 [P,NE,L,QSA]
 ```
 
 ### Using TCP ports
@@ -81,7 +81,7 @@ Those things being considered, you can put the following in your
 `.htaccess` file to enable forwarding requests to a port:
 
 ```ApacheConf
-    RewriteRule "^(.*)$" http://localhost:999/$1 [P,NE,L,QSA]
+RewriteRule "^(.*)$" http://localhost:999/$1 [P,NE,L,QSA]
 ```
 
 {{< alert type="info" >}}

--- a/content/tutorials/others/connect-to-irc.md
+++ b/content/tutorials/others/connect-to-irc.md
@@ -39,17 +39,17 @@ from source: <https://github.com/irssi/irssi>.
 ### Install irssi
 
 ```bash
-    $ sudo pacman -S irssi (Arch)
-    $ sudo yum install irssi (Redhat derivatives)
-    $ sudo apt-get install irssi (Debian derivatives)
+$ sudo pacman -S irssi (Arch)
+$ sudo yum install irssi (Redhat derivatives)
+$ sudo apt-get install irssi (Debian derivatives)
 ```
 
 ### Install screen
 
 ```bash
-    $ sudo pacman -S screen (Arch)
-    $ sudo yum install screen (Redhat derivatives)
-    $ sudo apt-get install screen (Debian derivatives)
+$ sudo pacman -S screen (Arch)
+$ sudo yum install screen (Redhat derivatives)
+$ sudo apt-get install screen (Debian derivatives)
 ```
 
 ## Configuring
@@ -57,7 +57,7 @@ from source: <https://github.com/irssi/irssi>.
 ### Create logging directory
 
 ```bash
-    mkdir ~/irclogs
+$ mkdir ~/irclogs
 ```
 
 Getting this ready for later...
@@ -65,7 +65,7 @@ Getting this ready for later...
 ### Check if screen is installed
 
 ```bash
-    screen -list
+$ screen -list
 ```
 
 If there's more than one screen session, you'll have to enter its name
@@ -74,7 +74,7 @@ at the end of the next command in Step 5.
 ### Start a screen session
 
 ```bash
-    screen -RD
+$ screen -RD
 ```
 
 Consult the GNU screen manual
@@ -83,7 +83,7 @@ Consult the GNU screen manual
 ### Start irssi
 
 ```bash
-    $ irssi
+$ irssi
 ```
 
 Having done this you should be presented with an empty `irssi` window.
@@ -92,18 +92,18 @@ Having done this you should be presented with an empty `irssi` window.
 
 Enter these commands in your `irssi` prompt.
 
-```irc
-    /SET nick <nick>
-    /SET alternate_nick <alternate nick>
-    /SET user_name <username>   # not necessary if ident enabled
-    /SET real_name <real name>
-    /SET use_msgs_window OFF
+```text
+/SET nick <nick>
+/SET alternate_nick <alternate nick>
+/SET user_name <username>   # not necessary if ident enabled
+/SET real_name <real name>
+/SET use_msgs_window OFF
 
-    # Highlight lines containing your nick
-    /HILIGHT <nick>
+# Highlight lines containing your nick
+/HILIGHT <nick>
 
-    # Set timestamp to something useful
-    /SET timestamp_format %d.%H:%M:%S
+# Set timestamp to something useful
+/SET timestamp_format %d.%H:%M:%S
 ```
 
 ### Set up logging
@@ -114,16 +114,16 @@ between the last time you checked IRC and the time the system
 restarted). It's also useful if you're receiving e.g. tech support, so
 you have a record of any instructions you were given!
 
-```irc
-    /SET autolog ON
-    /SET autolog_level ALL -CRAP -CLIENTCRAP -CTCPS
-    /SET autolog_path ~/irclogs/%Y/$tag/$0.%m-%d.log
+```text
+/SET autolog ON
+/SET autolog_level ALL -CRAP -CLIENTCRAP -CTCPS
+/SET autolog_path ~/irclogs/%Y/$tag/$0.%m-%d.log
 ```
 
 ### Set quit message
 
-```irc
-    /SET quit_message <message>
+```text
+/SET quit_message <message>
 ```
 
 Default is 'leaving,' mine is 'Scotty, beam me up!' (which is
@@ -135,34 +135,38 @@ TV series but said the above in Star Trek IV).
 
 For example, 'srcf'.
 
-```irc
-    /NETWORK ADD [-nick <nick>] <Network name (your choice)>
+```text
+/NETWORK ADD [-nick <nick>] <Network name (your choice)>
 ```
 
 ### Add one or more servers
 
 The FQDN in our case is `irc.srcf.net`.
 
-```irc
-    /SERVER ADD [-auto] -network <network name> <server FQDN>
+```text
+/SERVER ADD [-auto] -network <network name> <server FQDN>
 ```
 
 ### Add one or more channels
 
 Commands as follows:
 
-```irc
-    /CHANNEL ADD -auto #<channel name> <network name>
+```text
+/CHANNEL ADD -auto #<channel name> <network name>
 ```
 
 Move around windows until you get them in an order that you like (first
 go to the window that you wish to move):
 
-````irc
-    /wm <position to move to>
-    <or>
-    /window move <position to move to>
-````
+```text
+/wm <position to move to>
+```
+
+(or)
+
+```text
+/window move <position to move to>
+```
 
 Make sure to check out
 [an overview of the channels]({{< relref "/reference/other-services/internet-relay-chat-irc" >}}) on our
@@ -170,15 +174,15 @@ server to decide which ones to add.
 
 ### Save settings and layout
 
-```irc
-    /SAVE
-    /LAYOUT SAVE
+```text
+/SAVE
+/LAYOUT SAVE
 ```
 
 ### Restart irssi and confirm everything is set correctly
 
-```irc
-   /QUIT
+```text
+/QUIT
 ```
 
 You should now arrive at a terminal, where you can type ``irssi`` to restart the client and check that everything is working.
@@ -218,25 +222,35 @@ commands are not, so /NETWORK is precisely equivalent to /network.{{<  /alert >}
 - Remove servers (especially useful for getting rid of irssi's
     default servers):
 
-    `/NETWORK REMOVE <server>`
+    ```text
+    /NETWORK REMOVE <server>
+    ```
 
 - See all settings (to verify that there's nothing unexpected in
     there): switch to status window and type `/set`.
 - Indent (useful with very long lines, so messages can be
     distinguished; experiment with exact value):
 
-    `/SET indent 4`
+    ```text
+    /SET indent 4
+    ```
 
 - Quit irssi:
 
-    `/quit`
+    ```text
+    /quit
+    ```
 
 - Leave channel (after having gone to the channel's window):
 
-    ```irc
-        /part
-        <or>
-        /part <message>
+    ```text
+    /part
+    ```
+
+    (or)
+
+    ```text
+    /part <message>
     ```
 
 An alternative, but less elegant way, is to just close the window. This
@@ -254,21 +268,21 @@ window): `/wc` or, in full, `/WINDOW CLOSE`
 
 - Reload configuration:
 
-    ```irc
-        /RELOAD
-        /RELOAD <filename>   # for loading a different config file
+    ```text
+    /RELOAD
+    /RELOAD <filename>   # for loading a different config file
     ```
 
 - List users in the current channel:
 
-    ```irc
+    ```text
     /names
     /n
     ```
 
 - Display user information for a given \<nick\>:
 
-    ```irc
+    ```text
     /whois
     /wi
     ```
@@ -280,9 +294,9 @@ A number of useful things can be done here.
 If you are in relatively few channels that have problems with people
 joining/leaving frequently, then just ignore for that channel:
 
-```irc
-    /ignore #<channel> MODES JOINS PARTS QUITS
-    /ignore -except -pattern <yourNick> #<channel>
+```text
+/ignore #<channel> MODES JOINS PARTS QUITS
+/ignore -except -pattern <yourNick> #<channel>
 ```
 
 Replace \# with the wildcard operator (\*) to do this for all channels.
@@ -290,8 +304,8 @@ Replace \# with the wildcard operator (\*) to do this for all channels.
 An alternative way for doing this for all channels is to add the
 following to \~/.irssi/conf:
 
-```conf
-    ignores = ( { level = "JOINS PARTS QUITS"; } );
+```text
+ignores = ( { level = "JOINS PARTS QUITS"; } );
 ```
 
 For a more in depth discussion of levels, and how to put all

--- a/content/tutorials/others/connect-to-irc.md
+++ b/content/tutorials/others/connect-to-irc.md
@@ -39,17 +39,17 @@ from source: <https://github.com/irssi/irssi>.
 ### Install irssi
 
 ```bash
-$ sudo pacman -S irssi (Arch)
-$ sudo yum install irssi (Redhat derivatives)
-$ sudo apt-get install irssi (Debian derivatives)
+sudo pacman -S irssi # Arch
+sudo yum install irssi # Red Hat derivatives
+sudo apt-get install irssi # Debian derivatives
 ```
 
 ### Install screen
 
 ```bash
-$ sudo pacman -S screen (Arch)
-$ sudo yum install screen (Redhat derivatives)
-$ sudo apt-get install screen (Debian derivatives)
+sudo pacman -S screen # Arch
+sudo yum install screen # Red Hat derivatives
+sudo apt-get install screen # Debian derivatives
 ```
 
 ## Configuring
@@ -57,7 +57,7 @@ $ sudo apt-get install screen (Debian derivatives)
 ### Create logging directory
 
 ```bash
-$ mkdir ~/irclogs
+mkdir ~/irclogs
 ```
 
 Getting this ready for later...
@@ -65,7 +65,7 @@ Getting this ready for later...
 ### Check if screen is installed
 
 ```bash
-$ screen -list
+screen -list
 ```
 
 If there's more than one screen session, you'll have to enter its name
@@ -74,7 +74,7 @@ at the end of the next command in Step 5.
 ### Start a screen session
 
 ```bash
-$ screen -RD
+screen -RD
 ```
 
 Consult the GNU screen manual
@@ -83,7 +83,7 @@ Consult the GNU screen manual
 ### Start irssi
 
 ```bash
-$ irssi
+irssi
 ```
 
 Having done this you should be presented with an empty `irssi` window.

--- a/content/tutorials/others/virtual-desktops-over-vnc.md
+++ b/content/tutorials/others/virtual-desktops-over-vnc.md
@@ -28,11 +28,11 @@ SSH to `shell.srcf.net` using your SRCF username and password (SSH keys
 for your account are also valid), then run the `vncpasswd` command:
 
 ```bash
-    spqr2@pip:~$ vncpasswd
-    Using password file /home/spqr2/.vnc/passwd
-    Password:
-    Verify:
-    Would you like to enter a view-only password (y/n)? n
+spqr2@pip:~$ vncpasswd
+Using password file /home/spqr2/.vnc/passwd
+Password:
+Verify:
+Would you like to enter a view-only password (y/n)? n
 ```
 
 You can say no to a view-only password, for this use case it's unlikely
@@ -43,11 +43,11 @@ to be useful.
 To start a new VNC server process in the background:
 
 ```bash
-    spqr2@pip:~$ vncserver -geometry 1920x1080
-    New 'X' desktop is pip:12
+spqr2@pip:~$ vncserver -geometry 1920x1080
+New 'X' desktop is pip:12
 
-    Starting applications specified in /home/spqr2/.vnc/xstartup
-    Log file is /home/spqr2/.vnc/pip:12.log
+Starting applications specified in /home/spqr2/.vnc/xstartup
+Log file is /home/spqr2/.vnc/pip:12.log
 ```
 
 Geometry is of the form `<width>x<height>` and may be customised as
@@ -84,7 +84,7 @@ Back on your local machine, SSH to `shell.srcf.net` again, but request
 forwarding for your chosen port:
 
 ```bash
-    you@home:~$ ssh -N -L 5901:localhost:5912 shell.srcf.net
+you@home:~$ ssh -N -L 5901:localhost:5912 shell.srcf.net
 ```
 
 Replace `5912` with the **port number** for your VNC server (the display
@@ -130,7 +130,7 @@ preserved.
 Back over SSH to `shell.srcf.net`:
 
 ```bash
-    spqr2@pip:~$ vncserver -kill :12
+spqr2@pip:~$ vncserver -kill :12
 ```
 
 Replace `:12` with the **port number** for your VNC server.

--- a/content/tutorials/others/virtual-desktops-over-vnc.md
+++ b/content/tutorials/others/virtual-desktops-over-vnc.md
@@ -27,7 +27,7 @@ native SSH client.
 SSH to `shell.srcf.net` using your SRCF username and password (SSH keys
 for your account are also valid), then run the `vncpasswd` command:
 
-```bash
+```text
 spqr2@pip:~$ vncpasswd
 Using password file /home/spqr2/.vnc/passwd
 Password:
@@ -42,7 +42,7 @@ to be useful.
 
 To start a new VNC server process in the background:
 
-```bash
+```text
 spqr2@pip:~$ vncserver -geometry 1920x1080
 New 'X' desktop is pip:12
 
@@ -83,7 +83,7 @@ your choosing on your local machine.
 Back on your local machine, SSH to `shell.srcf.net` again, but request
 forwarding for your chosen port:
 
-```bash
+```text
 you@home:~$ ssh -N -L 5901:localhost:5912 shell.srcf.net
 ```
 
@@ -129,7 +129,7 @@ preserved.
 
 Back over SSH to `shell.srcf.net`:
 
-```bash
+```text
 spqr2@pip:~$ vncserver -kill :12
 ```
 

--- a/content/tutorials/shell-and-files/passwordless-login.md
+++ b/content/tutorials/shell-and-files/passwordless-login.md
@@ -25,13 +25,13 @@ When logging in to a server, the SSH client on your computer requests the public
 2. Paste in the following command with an email of your choice
 
     ```bash
-        $ ssh-keygen -t ed25519 -C "your_email@example.com"
+    $ ssh-keygen -t ed25519 -C "your_email@example.com"
     ```
 
     This creates an SSH key pair, using your email as a label. You should wee the following output
 
-    ```bash
-        > Generating public/private ed25519 key pair.
+    ```text
+    Generating public/private ed25519 key pair.
     ```
 
 3. When you're prompted to "Enter a file in which to save the key," press Enter. This accepts the default file location, which is in the `.ssh` directory in your home directory.
@@ -52,7 +52,7 @@ You now need to add your public key to one of our servers. Since all of our user
 A handy utility exists for this:
 
 ```bash
-    ssh-copy-id -i ~/.ssh/mykey spqr2@pip.srcf.net
+ssh-copy-id -i ~/.ssh/mykey spqr2@pip.srcf.net
 ```
 
 More useful information on that [here](https://www.ssh.com/academy/ssh/copy-id).
@@ -63,9 +63,9 @@ If that doesn't work, you can always upload your public key to the server as you
 Make sure you upload your **public** key, not your **private** key. To check, you can always open the file in question and if it contains something like the following then you know it's the private key.
 
 ```text
-    -----BEGIN PRIVATE KEY-----
-    BASE64 ENCODED DATA
-    -----END PRIVATE KEY-----
+-----BEGIN PRIVATE KEY-----
+BASE64 ENCODED DATA
+-----END PRIVATE KEY-----
 ```
 
 {{<  /alert >}}

--- a/content/tutorials/shell-and-files/passwordless-login.md
+++ b/content/tutorials/shell-and-files/passwordless-login.md
@@ -25,7 +25,7 @@ When logging in to a server, the SSH client on your computer requests the public
 2. Paste in the following command with an email of your choice
 
     ```bash
-    $ ssh-keygen -t ed25519 -C "your_email@example.com"
+    ssh-keygen -t ed25519 -C "your_email@example.com"
     ```
 
     This creates an SSH key pair, using your email as a label. You should wee the following output

--- a/content/tutorials/shell-and-files/terminal-guide.md
+++ b/content/tutorials/shell-and-files/terminal-guide.md
@@ -33,7 +33,7 @@ you to the system and telling you any recent news, followed by a
 *command prompt*:
 
 ```bash
-    pip:~$
+pip:~$
 ```
 
 You are now logged in and can give the system commands by typing them
@@ -42,9 +42,9 @@ is just the name of the program you wish to run. For example typing
 'date' and pressing return will tell you the current date and time:
 
 ```bash
-    pip:~$ date
-    Wed Apr  5 22:29:11 BST 2020
-    pip:~$
+pip:~$ date
+Wed Apr  5 22:29:11 BST 2020
+pip:~$
 ```
 
 After each command has finished, a new prompt will be displayed ready
@@ -60,15 +60,15 @@ used to check the speed of an Internet connection, requires the name of
 a host as an argument:
 
 ```bash
-    pip:~$ ping www.bbc.co.uk
-    PING www.bbc.net.uk (212.58.224.35): 56 data bytes
-    64 bytes from 212.58.224.35: icmp_seq=0 ttl=247 time=4.9 ms
-    64 bytes from 212.58.224.35: icmp_seq=1 ttl=247 time=4.6 ms
+pip:~$ ping www.bbc.co.uk
+PING www.bbc.net.uk (212.58.224.35): 56 data bytes
+64 bytes from 212.58.224.35: icmp_seq=0 ttl=247 time=4.9 ms
+64 bytes from 212.58.224.35: icmp_seq=1 ttl=247 time=4.6 ms
 
-    --- www.bbc.net.uk ping statistics ---
-    2 packets transmitted, 2 packets received, 0% packet loss
-    round-trip min/avg/max = 4.6/4.7/4.9 ms
-    pip:~$
+--- www.bbc.net.uk ping statistics ---
+2 packets transmitted, 2 packets received, 0% packet loss
+round-trip min/avg/max = 4.6/4.7/4.9 ms
+pip:~$
 ```
 
 (To stop the 'ping' program, press control-c)
@@ -110,17 +110,17 @@ working directory. All directories have a special subdirectory called
 To find out your current directory, use the command `pwd`:
 
 ```bash
-    pip:~$ pwd
-    /users/abc45
-    pip:~$
+pip:~$ pwd
+/users/abc45
+pip:~$
 ```
 
 You can change the working directory by using the `cd` command, for
 example:
 
 ```bash
-    pip:~$ cd my_dir
-    pip:~/my_dir$ 
+pip:~$ cd my_dir
+pip:~/my_dir$
 ```
 
 Notice how the working directory is displayed as part of the command
@@ -130,9 +130,9 @@ in other words the directory you start off in when you first log in.
 To view the contents of the working directory, use the command 'ls':
 
 ```bash
-    pip:~$ ls
-    public_html  mygroup  my_file.txt
-    pip:~$
+pip:~$ ls
+public_html  mygroup  my_file.txt
+pip:~$
 ```
 
 Alternatively, use `ls -alF` to give more detailed information. The

--- a/content/tutorials/shell-and-files/terminal-guide.md
+++ b/content/tutorials/shell-and-files/terminal-guide.md
@@ -32,8 +32,8 @@ After sucessfully loging in you will see a few lines of text welcoming
 you to the system and telling you any recent news, followed by a
 *command prompt*:
 
-```bash
-pip:~$
+```text
+sqpr2@pip:~$
 ```
 
 You are now logged in and can give the system commands by typing them
@@ -41,10 +41,10 @@ after the prompt. If you wish to start a particular program, the command
 is just the name of the program you wish to run. For example typing
 'date' and pressing return will tell you the current date and time:
 
-```bash
-pip:~$ date
+```text
+spqr2@pip:~$ date
 Wed Apr  5 22:29:11 BST 2020
-pip:~$
+spqr2@pip:~$
 ```
 
 After each command has finished, a new prompt will be displayed ready
@@ -59,8 +59,8 @@ alter the way that they run, for example the command 'ping', which is
 used to check the speed of an Internet connection, requires the name of
 a host as an argument:
 
-```bash
-pip:~$ ping www.bbc.co.uk
+```text
+spqr2@pip:~$ ping www.bbc.co.uk
 PING www.bbc.net.uk (212.58.224.35): 56 data bytes
 64 bytes from 212.58.224.35: icmp_seq=0 ttl=247 time=4.9 ms
 64 bytes from 212.58.224.35: icmp_seq=1 ttl=247 time=4.6 ms
@@ -68,7 +68,7 @@ PING www.bbc.net.uk (212.58.224.35): 56 data bytes
 --- www.bbc.net.uk ping statistics ---
 2 packets transmitted, 2 packets received, 0% packet loss
 round-trip min/avg/max = 4.6/4.7/4.9 ms
-pip:~$
+spqr2@pip:~$
 ```
 
 (To stop the 'ping' program, press control-c)
@@ -109,18 +109,18 @@ working directory. All directories have a special subdirectory called
 
 To find out your current directory, use the command `pwd`:
 
-```bash
-pip:~$ pwd
+```text
+spqr2@pip:~$ pwd
 /users/abc45
-pip:~$
+spqr2@pip:~$
 ```
 
 You can change the working directory by using the `cd` command, for
 example:
 
-```bash
-pip:~$ cd my_dir
-pip:~/my_dir$
+```text
+spqr2@pip:~$ cd my_dir
+spqr2@pip:~/my_dir$
 ```
 
 Notice how the working directory is displayed as part of the command
@@ -129,10 +129,10 @@ in other words the directory you start off in when you first log in.
 
 To view the contents of the working directory, use the command 'ls':
 
-```bash
-pip:~$ ls
+```text
+spqr2@pip:~$ ls
 public_html  mygroup  my_file.txt
-pip:~$
+spqr2@pip:~$
 ```
 
 Alternatively, use `ls -alF` to give more detailed information. The

--- a/content/tutorials/websites/deploy-a-web-app.md
+++ b/content/tutorials/websites/deploy-a-web-app.md
@@ -44,20 +44,20 @@ created your `venv`.
 1. Create a directory for your app to live in:
 
     ```bash
-        mkdir -p ~/myapp
-        cd ~/myapp
+    mkdir -p ~/myapp
+    cd ~/myapp
     ```
 
 2. Set up a venv
 
     ```bash
-        python3 -m venv venv
+    python3 -m venv venv
     ```
 
 3. Activate the venv
 
     ```bash
-        . venv/bin/activate
+    . venv/bin/activate
     ```
 
     You should do this step every time before running your app or
@@ -79,8 +79,8 @@ responsibility to keep your node installations and `nvm` itself updated.
 1. Create a directory for your app to live in:
 
     ```bash
-        mkdir -p ~/myapp
-        cd ~/myapp
+    mkdir -p ~/myapp
+    cd ~/myapp
     ```
 
 2. Install `nvm` in your home directory. You'll need to find the
@@ -89,7 +89,7 @@ responsibility to keep your node installations and `nvm` itself updated.
     the time of writing, it looks like this:
 
     ```bash
-        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
     ```
 
     {{< alert type="danger" >}}
@@ -101,8 +101,8 @@ Piping a script straight into your shell is potentially dangerous as you are all
 3. Install whatever version of `node.js` you want.
 
     ```bash
-        nvm install 12
-        nvm alias default 12
+    nvm install 12
+    nvm alias default 12
     ```
 
 4. Done! The version of `node.js` you specified is now installed and
@@ -116,38 +116,38 @@ easily install and manage dependencies and versions.
 1. Create a directory for your app to live in:
 
     ```bash
-        mkdir -p ~/myapp
-        cd ~/myapp
+    mkdir -p ~/myapp
+    cd ~/myapp
     ```
 
 2. Install `rbenv` in your home directory:
 
     ```bash
-        git clone https://github.com/rbenv/rbenv.git ~/.rbenv
-        cd ~/.rbenv && src/configure && make -C src
-        echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
-        ~/.rbenv/bin/rbenv init
+    git clone https://github.com/rbenv/rbenv.git ~/.rbenv
+    cd ~/.rbenv && src/configure && make -C src
+    echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
+    ~/.rbenv/bin/rbenv init
     ```
 
 3. Follow the printed instructions on appending to your `~/.bashrc`
     file:
 
     ```bash
-        echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+    echo 'eval "$(rbenv init -)"' >> ~/.bashrc
     ```
 
 4. Install `ruby-build` as a plugin:
 
     ```bash
-        mkdir -p "$(rbenv root)"/plugins
-        git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
+    mkdir -p "$(rbenv root)"/plugins
+    git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
     ```
 
 5. Install whichever version of Ruby you want.
 
     ```bash
-        rbenv install 2.6.6
-        rbenv local 2.6.6
+    rbenv install 2.6.6
+    rbenv local 2.6.6
     ```
 
 6. Done! You now have a working Ruby installation that's hooked into
@@ -188,9 +188,9 @@ If you're logged in via ssh, you can find the code at
 To create a skeleton Django project:
 
 ```bash
-    django-admin startproject example
-    mv example python
-    cd python
+django-admin startproject example
+mv example python
+cd python
 ```
 
 Now take a look at `django/example/settings.py` for how to configure
@@ -203,8 +203,8 @@ Ruby on Rails is arguably one of the most popular and influential web
 frameworks. To create a skeleton Rails project:
 
 ```bash
-    gem install rails
-    rails new myapp
+gem install rails
+rails new myapp
 ```
 
 You should now have a new Ruby on Rails project setup in the `myapp`
@@ -216,11 +216,11 @@ Sinatra is a lightweight web microframework that's well suited to
 simple projects. To install it run `gem install sinatra` and then put
 the following in `myapp.rb`:
 
-```bash
-    require 'sinatra'
-    get '/' do
-        'Hello world!'
-    end
+```ruby
+require 'sinatra'
+get '/' do
+    'Hello world!'
+end
 ```
 
 You can then run this by typing `ruby myapp.rb` and going to
@@ -255,11 +255,11 @@ The scripts provided here are just examples and won't necessarily be perfect for
 #### Python
 
 ```bash
-    #!/bin/bash -e
+#!/bin/bash -e
 
-    . ~/myapp/venv/bin/activate
-    exec gunicorn -w 2 -b unix:/home/crsid/myapp/web.sock \
-        --log-file - main:app
+. ~/myapp/venv/bin/activate
+exec gunicorn -w 2 -b unix:/home/crsid/myapp/web.sock \
+    --log-file - main:app
 ```
 
 Replace `main:app` with the module containing the app, and name of your
@@ -268,15 +268,15 @@ app.
 #### Node
 
 ```bash
-    #!/bin/bash -e
+#!/bin/bash -e
 
-    USER="$(whoami)"
-    [ -e "/home/crsid/myapp/web.sock" ] && rm "/home/crsid/myapp/web.sock"
-    umask 0
+USER="$(whoami)"
+[ -e "/home/crsid/myapp/web.sock" ] && rm "/home/crsid/myapp/web.sock"
+umask 0
 
-    . ~/.nvm/nvm.sh
-    NODE_ENV=production PORT="/home/crsid/myapp/web.sock" \
-        exec ~/myapp/src/bin/www
+. ~/.nvm/nvm.sh
+NODE_ENV=production PORT="/home/crsid/myapp/web.sock" \
+    exec ~/myapp/src/bin/www
 ```
 
 Replace `~/myapp/src/bin/www` with the path to your app.
@@ -284,12 +284,12 @@ Replace `~/myapp/src/bin/www` with the path to your app.
 #### Ruby
 
 ```bash
-    #!/bin/bash -e
+#!/bin/bash -e
 
-    eval "$(rbenv init -)"
-    cd ~/myapp/src
-    RAILS_ENV=production \
-          exec bin/rails server -b /home/crsid/myapp/web.sock
+eval "$(rbenv init -)"
+cd ~/myapp/src
+RAILS_ENV=production \
+      exec bin/rails server -b /home/crsid/myapp/web.sock
 ```
 
 Replace `~/myapp/src` with the path to your app.
@@ -297,7 +297,7 @@ Replace `~/myapp/src` with the path to your app.
 Now, for all frameworks, make the `run.sh` script executable:
 
 ```bash
-    chmod +x ~/myapp/run
+chmod +x ~/myapp/run
 ```
 
 You should now be able to execute the script and access your website (or
@@ -317,8 +317,8 @@ crashes. We highly recommend using `systemd` to supervise your app.
     move on to the next step. Otherwise, an example would be:
 
     ```bash
-        #!/bin/sh -e
-        exec ~/myapp/run-server
+    #!/bin/sh -e
+    exec ~/myapp/run-server
     ```
 
     Your server should run in the *foreground* (it should not
@@ -337,7 +337,7 @@ crashes. We highly recommend using `systemd` to supervise your app.
     if it doesn't exist:
 
     ```bash
-        mkdir -p ~/.config/systemd/user
+    mkdir -p ~/.config/systemd/user
     ```
 
     For a group account, substitute `~` for `/societies/foosoc`, where
@@ -348,20 +348,21 @@ crashes. We highly recommend using `systemd` to supervise your app.
     `/societies/foosoc/.config/systemd/user/myapp.service` for groups):
 
     ```ini
-        [Unit]
-        Description={YOUR USER, SOCIETY OR GROUP NAME} Webapp
-        ConditionHost=sinkhole
+    [Unit]
+    Description={YOUR USER, SOCIETY OR GROUP NAME} Webapp
+    ConditionHost=sinkhole
 
-        [Install]
-        WantedBy=default.target
+    [Install]
+    WantedBy=default.target
 
-        [Service]
-        ExecStart=/home/{CRSid}/myapp/run
-        Restart=always
+    [Service]
+    ExecStart=/home/{CRSid}/myapp/run
+    Restart=always
     ```
 
 4. Tell systemd to start your app on startup, by running
     `systemctl --user enable myapp`.
+
 5. You'll need to start your app manually once (on future reboots, it
     will be started for you). To do that, run
     `systemctl --user start myapp`.
@@ -401,14 +402,14 @@ systemd that fact by adding the following line under `[Service]` in your
 systemd unit file:
 
 ```ini
-    ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=/bin/kill -HUP $MAINPID
 ```
 
 and then running `systemctl --user daemon-reload`. After that, you can
 use `systemctl` to reload your app:
 
 ```bash
-    systemctl --user reload myapp
+systemctl --user reload myapp
 ```
 
 ### Notes for Ruby

--- a/content/tutorials/websites/deploy-a-web-app.md
+++ b/content/tutorials/websites/deploy-a-web-app.md
@@ -254,7 +254,7 @@ The scripts provided here are just examples and won't necessarily be perfect for
 
 #### Python
 
-```bash
+```sh
 #!/bin/bash -e
 
 . ~/myapp/venv/bin/activate
@@ -267,7 +267,7 @@ app.
 
 #### Node
 
-```bash
+```sh
 #!/bin/bash -e
 
 USER="$(whoami)"
@@ -283,7 +283,7 @@ Replace `~/myapp/src/bin/www` with the path to your app.
 
 #### Ruby
 
-```bash
+```sh
 #!/bin/bash -e
 
 eval "$(rbenv init -)"
@@ -316,7 +316,7 @@ crashes. We highly recommend using `systemd` to supervise your app.
     for Django, Node or Rails, you've already created this file, so can
     move on to the next step. Otherwise, an example would be:
 
-    ```bash
+    ```sh
     #!/bin/sh -e
     exec ~/myapp/run-server
     ```

--- a/content/tutorials/websites/wordpress-from-scratch.md
+++ b/content/tutorials/websites/wordpress-from-scratch.md
@@ -86,14 +86,14 @@ files on the server. To make this work you can add the following few
 lines to your `wp-config`.php, near the bottom but above the line that
 says 'stop editing':
 
-```ApacheConf
-    # Force WordPress to use direct filesystem access so that upgrades work properly.
-    # https://core.trac.wordpress.org/ticket/10205
-    # https://codex.wordpress.org/Editing_wp-config.php
+```php
+# Force WordPress to use direct filesystem access so that upgrades work properly.
+# https://core.trac.wordpress.org/ticket/10205
+# https://codex.wordpress.org/Editing_wp-config.php
 
-    define('FS_METHOD', 'direct');
-    define('FS_CHMOD_DIR', (02775 & ~ umask()));
-    define('FS_CHMOD_FILE', (0664 & ~ umask()));
+define('FS_METHOD', 'direct');
+define('FS_CHMOD_DIR', (02775 & ~ umask()));
+define('FS_CHMOD_FILE', (0664 & ~ umask()));
 ```
 
 If configured correctly, the updates page should include text similar to

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -386,8 +386,7 @@ docs-specific classes
 
 .highlight > pre {
   border-radius: 5px;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+  padding: 0.5rem 0.8rem;
 }
 
 .footer a {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -389,6 +389,18 @@ docs-specific classes
   padding: 0.5rem 0.8rem;
 }
 
+.highlight code.language-bash::before {
+  content: "$ ";
+  position: absolute;
+  left: 0;
+  color: #aaa;
+}
+.highlight code.language-bash {
+  display: inline-block;
+  position: relative;
+  padding-left: 1rem;
+}
+
 .footer a {
   text-decoration: none;
 }


### PR DESCRIPTION
There's a handful of changes here related to fenced code blocks across the docs:

* 4-space indents have been removed (they appear verbatim in the rendered code)
* code block types have been set to `text` when missing (to avoid inconsistent non-highlight rendering)
* certain invalid keywords like `irc` have been substituted
* shell command blocks now use a CSS-positioned `$` so it doesn't get copied when selecting the block
  * shell session examples now use the `text` type (note that `bash-session` isn't available in our version of Hugo)
  * bash scripts use the `sh` type

This PR should cover my list of considerations in https://github.com/SRCF/docs/pull/47#issuecomment-1050833907.