### PR TITLE
Add troubleshooting advice to 'Shell: Logging in' for when ssh sets $TERM to an unsupported value.

### DIFF
--- a/content/reference/shell-and-files/ssh.md
+++ b/content/reference/shell-and-files/ssh.md
@@ -79,3 +79,30 @@ please use **doom**, which has fingerprints:
     ED25519  SHA256:kh1Sr6Nrlp/vK9ijKZ43/IQ2tqdPzY/fnZdnGBIKgIM
     RSA      MD5:f1:ee:8c:a7:7a:cb:f7:c7:dc:c5:7e:56:9a:83:f5:bc
     RSA      SHA256:c1dlaFnPyJ44CnjZIeV6zLHQCPlIH9Og0K3dL16XGfo
+
+
+## Troubleshooting
+
+### Unsupported term-type environment variable
+If the terminal behaves incorrectly on certain keypresses - such as by
+outputting weird glyphs, or by not removing characters when inputting a
+backspace - then it is possible ssh has misconfigured the `TERM`
+environment variable.
+
+This can be checked by running `toe -a | grep $TERM`. (`toe -a` lists
+all supported values for the `TERM` variable, and `| grep $TERM`
+performs a search within `toe`'s output to try to find your session's
+value of `$TERM`). If running the command shows no output, then your
+value of `TERM` is unsupported.
+
+You can manually correct this by running `export TERM=xterm-256color`.
+This command would have to be ran once after the start of each session.
+To correct this persistently, run the following command **on your
+device**:
+```
+infocmp -a $TERM | ssh <Your CRSid>@shell.srcf.net tic -x -o \~/.terminfo/ -
+```
+This will install your device's terminal-type to your account's home
+directory (inside `~/.terminfo/`). You will not need to make any manual
+changes to contents of this directory. Your terminal should now work
+correctly for all subsequent sessions.

--- a/content/reference/shell-and-files/ssh.md
+++ b/content/reference/shell-and-files/ssh.md
@@ -95,12 +95,16 @@ performs a search within `toe`'s output to try to find your session's
 value of `$TERM`). If running the command shows no output, then your
 value of `TERM` is unsupported.
 
-You can manually correct this by running `export TERM=xterm-256color`.
-This command would have to be ran once after the start of each session.
-To correct this persistently, run the following command **on your
-device**:
+You can temporarily select a more general terminal type
+(`xterm-256color` should work) for your session by setting the `TERM`
+environment variable when running `ssh`:
+```bash
+TERM=xterm-256color ssh ...
 ```
-infocmp -a $TERM | ssh <Your CRSid>@shell.srcf.net tic -x -o \~/.terminfo/ -
+To correct this persistently, run the following command (on your
+device):
+```bash
+infocmp -a $TERM | ssh <Your CRSid>@shell.srcf.net tic -x -
 ```
 This will install your device's terminal-type to your account's home
 directory (inside `~/.terminfo/`). You will not need to make any manual

--- a/content/tutorials/shell-and-files/logging-in.md
+++ b/content/tutorials/shell-and-files/logging-in.md
@@ -81,25 +81,8 @@ organized mess!
 {{< alert type="info" >}}
 If the terminal behaves incorrectly on certain keypresses - such as by
 outputting weird glyphs, or by not removing characters when inputting a
-backspace - then it is possible ssh has misconfigured the `TERM`
-environment variable.
-
-This can be checked by running `toe -a | grep $TERM`. (`toe -a` lists
-all supported values for the `TERM` variable, and `| grep $TERM`
-performs a search within `toe`'s output to try to find your session's
-value of `$TERM`). If running the command shows no output, then your
-value of `TERM` is unsupported.
-
-You can manually correct this by running `export TERM=xterm-256color`.
-This command would have to be ran once at the start of each session.
-To correct this persistently, create a file named `config` (with no
-file extension) **on your device** at the path `~/.ssh/config` (on
-Linux or macOS) or `$HOME\.ssh\config` (on Windows) containing this
-text:
-```
-Host shell.srcf.net
-    SetEnv TERM=xterm-256color
-```
+backspace - [then it is possible ssh has misconfigured the `TERM`
+environment variable.]({{< relref "/reference/shell-and-files/ssh#unsupported-term-type-environment-variable" >}})
 {{<  /alert >}}
 
 The last command we'll try is `cd public_html`. This **changes your

--- a/content/tutorials/shell-and-files/logging-in.md
+++ b/content/tutorials/shell-and-files/logging-in.md
@@ -78,6 +78,30 @@ complex and multi-layered file system on our shell server, which happens
 to be your home directory. `pwd` tells you where you are in this
 organized mess!
 
+{{< alert type="info" >}}
+If the terminal behaves incorrectly on certain keypresses - such as by
+outputting weird glyphs, or by not removing characters when inputting a
+backspace - then it is possible ssh has misconfigured the `TERM`
+environment variable.
+
+This can be checked by running `toe -a | grep $TERM`. (`toe -a` lists
+all supported values for the `TERM` variable, and `| grep $TERM`
+performs a search within `toe`'s output to try to find your session's
+value of `$TERM`). If running the command shows no output, then your
+value of `TERM` is unsupported.
+
+You can manually correct this by running `export TERM=xterm-256color`.
+This command would have to be ran once at the start of each session.
+To correct this persistently, create a file named `config` (with no
+file extension) **on your device** at the path `~/.ssh/config` (on
+Linux or macOS) or `$HOME\.ssh\config` (on Windows) containing this
+text:
+```
+Host shell.srcf.net
+    SetEnv TERM=xterm-256color
+```
+{{<  /alert >}}
+
 The last command we'll try is `cd public_html`. This **changes your
 directory** to `public_html`. You're now on a different street!
 


### PR DESCRIPTION
ssh passes the client's value of $TERM to the server by default, and the srcf terminals don't support all terminal types. (Mine was `xterm-kitty` from the kitty term emulator - and kitty gets picked as the default term emulator by some distros (or, well, at least my compositor did))

the wording might be a little dry compared to the rest of the tutorial, but hopefully this just wont get read by most people.

another (maybe easier?) way to have the envvar persist would be to have the reader put the `export ...` command above line 39 in `~/.bashrc`, but that's a (scary looking) hidden file, so maybe not intuitive unless the reader ran `ls -la` earlier in the page and spotted it.

also, having a `~/.ssh/config` file is nice because it lets you add a `User <CRSid>` line under the `Host shell.srcf.net` header to skip having to name the user with `ssh`.

i hope I didn't get anything wrong 