### PR TITLE
Correct filepath of script in systemd service

### DIFF
--- a/content/tutorials/websites/deploy-a-web-app.md
+++ b/content/tutorials/websites/deploy-a-web-app.md
@@ -297,7 +297,7 @@ Replace `~/myapp/src` with the path to your app.
 Now, for all frameworks, make the `run.sh` script executable:
 
 ```bash
-chmod +x ~/myapp/run
+chmod +x ~/myapp/run.sh
 ```
 
 You should now be able to execute the script and access your website (or

--- a/content/tutorials/websites/deploy-a-web-app.md
+++ b/content/tutorials/websites/deploy-a-web-app.md
@@ -356,7 +356,7 @@ crashes. We highly recommend using `systemd` to supervise your app.
     WantedBy=default.target
 
     [Service]
-    ExecStart=/home/{CRSid}/myapp/run
+    ExecStart=/home/{CRSid}/myapp/run.sh
     Restart=always
     ```
 


### PR DESCRIPTION
The startup script was named `~/myapp/run.sh`, and the systemd service script path must match.