### PR TITLE
Set `PYTHONPATH` to avoid `ModuleNotFoundError`

### DIFF
--- a/content/tutorials/websites/deploy-a-web-app.md
+++ b/content/tutorials/websites/deploy-a-web-app.md
@@ -258,6 +258,7 @@ The scripts provided here are just examples and won't necessarily be perfect for
 #!/bin/bash -e
 
 . ~/myapp/venv/bin/activate
+export PYTHONPATH='/home/crsid/myapp'
 exec gunicorn -w 2 -b unix:/home/crsid/myapp/web.sock \
     --log-file - main:app
 ```

--- a/content/tutorials/websites/deploy-a-web-app.md
+++ b/content/tutorials/websites/deploy-a-web-app.md
@@ -258,7 +258,7 @@ The scripts provided here are just examples and won't necessarily be perfect for
 #!/bin/bash -e
 
 . ~/myapp/venv/bin/activate
-export PYTHONPATH='/home/crsid/myapp'
+cd ~/myapp
 exec gunicorn -w 2 -b unix:/home/crsid/myapp/web.sock \
     --log-file - main:app
 ```
@@ -357,6 +357,7 @@ crashes. We highly recommend using `systemd` to supervise your app.
     WantedBy=default.target
 
     [Service]
+    WorkingDirectory=/home/{CRSid}/myapp
     ExecStart=/home/{CRSid}/myapp/run.sh
     Restart=always
     ```


### PR DESCRIPTION
The startup script for the Python app ran fine from the console, but not when run as a systemd service, causing the following error when launching gunicorn.
```console
ModuleNotFound error: No module named 'main'
```
Set `PYTHONPATH` before launching gunicorn to avoid this.