### PR TITLE
Added recommendation to use Purpur to wiki

### DIFF
--- a/content/reference/other-services/game-servers.md
+++ b/content/reference/other-services/game-servers.md
@@ -28,9 +28,9 @@ high-numbered ports at random until you find one that isn't in use.
 
 ## Minecraft
 
-### Recommended server software
+### Suggested server software
 
-To reduce the load on `doom.srcf.net`, please use a distribution such as [Purpur](https://purpurmc.org/).
+For higher server performance, consider using a server distribution such as [Purpur](https://purpurmc.org/) or [Paper](https://papermc.io/)_.
 
 ## Running at startup
 

--- a/content/reference/other-services/game-servers.md
+++ b/content/reference/other-services/game-servers.md
@@ -26,6 +26,12 @@ port for your application will be in use. We don't have any specific
 rules for picking a port for your application, so just pick
 high-numbered ports at random until you find one that isn't in use.
 
+## Minecraft
+
+### Recommended server software
+
+To reduce the load on `doom.srcf.net`, please use a distribution such as [Purpur](https://purpurmc.org/).
+
 ## Running at startup
 
 If you want your server application to run at system startup, you can

--- a/content/reference/other-services/game-servers.md
+++ b/content/reference/other-services/game-servers.md
@@ -30,7 +30,7 @@ high-numbered ports at random until you find one that isn't in use.
 
 ### Suggested server software
 
-For higher server performance, consider using a server distribution such as [Purpur](https://purpurmc.org/) or [Paper](https://papermc.io/)_.
+For higher server performance, consider using a server distribution such as [Purpur](https://purpurmc.org/) or [Paper](https://papermc.io/).
 
 ## Running at startup
 


### PR DESCRIPTION
Since `doom` has a high proportion of resources consumed by Minecraft servers, I have added a suggestion to the wiki to use https://purpurmc.org/, which should allow for reduced congestion on `doom` (and hopefully better TPS).