### PR TITLE
Fix typos, reduce repetition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Makefile.local
 .idea/
 .venv/
 public/*
+.hugo_build.lock

--- a/archetypes/tutorials.md
+++ b/archetypes/tutorials.md
@@ -12,10 +12,4 @@ toc: true
 
 ## Closing remarks
 
-Did you like this or find this cool? We invite you to check out
-[more tutorials]({{< relref "/tutorials" >}})
-or [get in touch]({{< relref "/#help-and-support" >}}) to tell us what you thought!
-
-If you have any suggestions for how we could improve this documentation
-please send us an email at `support@srcf.net` or submit a Pull Request
-on [GitHub](https://github.com/SRCF/docs)!
+{{< closing_remarks >}}

--- a/content/guides/society-handovers.md
+++ b/content/guides/society-handovers.md
@@ -34,7 +34,7 @@ The new webmaster must register for an SRCF account beforehand, if they don't al
 
 If possible, you may consider keeping the old webmaster as an admin on the account. We recommend two or more admins to ensure the longevity of the society account in case one or more admins become unreachable.
 
-If you are using a content mangement system like WordPress, this is also the time to add the new webmaster via the web interface as an administrator of the website.
+If you are using a content management system like WordPress, this is also the time to add the new webmaster via the web interface as an administrator of the website.
 
 ## Check details
 
@@ -46,7 +46,7 @@ Once the new webmaster is added, the incumbent webmaster should explain how the 
 
 In the majority of cases where a content management system is used (like WordPress), "updating" can be done via the handy web interface. If something goes wrong though, it is necessary to log in and poke around at the files. We've written tutorials for this.
 
-At this point, the new webmaster should also read our reference material on group accounts, especially on file permissions and how our web services work. The gist of it is that all content gets served from `/public/societies/<socname>/public_html` and private society files are located at `/societies/<socname>/`. Shortcutes (symbolic links) to these are automatically added to your home directory.
+At this point, the new webmaster should also read our reference material on group accounts, especially on file permissions and how our web services work. The gist of it is that all content gets served from `/public/societies/<socname>/public_html` and private society files are located at `/societies/<socname>/`. Shortcuts (symbolic links) to these are automatically added to your home directory.
 
 ## Email forwarding
 

--- a/content/guides/websites/securing-wordpress.md
+++ b/content/guides/websites/securing-wordpress.md
@@ -28,13 +28,13 @@ risks can be minimized by following the hardening steps below.
 3. We also recommend you disable *Allow link notifications from other
     blogs (pingbacks and trackbacks)* on new posts, under `Settings` \>
     `Discussion` in the admin panel.
-4. Activate a spam filtering plugin like Akismet and a capatcha system
+4. Activate a spam filtering plugin like Akismet and a captcha system
     like reCAPTCHA. Akismet is installed by default and just needs
     activiating. Go to `.../wp-admin/plugins.php` to install and
     activate plugins.
-5. You may optionaly want to modify your theme so that it no longer
+5. You may optionally want to modify your theme so that it no longer
     puts the Wordpress version into the html - this may help stop
-    hackers finding that you installation is outdated but it does not
+    hackers finding that your installation is outdated but it does not
     protect against problems caused by the version you are using being
     compromised.
 6. Regularly check up on the status of your installation and keep an

--- a/content/reference/email/legacy-mail-on-pip.md
+++ b/content/reference/email/legacy-mail-on-pip.md
@@ -9,7 +9,7 @@ toc: true
 {{< alert type="info" >}}
 
 This information applies only to users of the 'legacy' or 'advanced'
-SRCF mail server. It might apply to you if you had a SRCF account before
+SRCF mail server. It might apply to you if you had an SRCF account before
 October 2018, or you deliberately chose to handle your mail this way.
 
 To see which email system you are currently using, see the [control
@@ -154,7 +154,7 @@ files. This leads to confusion, and also can lead to your entire home
 directory being served over IMAP, which has been known to upset email
 software (unsurprisingly).
 
-And for added confusion, Mbox is incapable of storing any email containg
+And for added confusion, Mbox is incapable of storing any email containing
 a line of text starting with the word 'From'. Yes, really. (Mail
 software has to rewrite it as `>From` as a workaround.)
 

--- a/content/tutorials/others/connect-to-irc.md
+++ b/content/tutorials/others/connect-to-irc.md
@@ -338,15 +338,9 @@ useful commands listed in the screen manual, and a few are listed below
 - `ctrl+a c` creates a new window.
 - `ctrl+a n` switches to the next window.
 
-## Suggestions/improvements?
+## Closing remarks
 
-Did you like this or find this cool? We invite you to check out
-[more tutorials]({{< relref "/tutorials" >}})
-
-If you have a better way to join the SRCF IRC server (or any other
-suggestions for how we could improve this documentation), send us an
-email at `support@srcf.net` or submit a Pull Request on
-[GitHub](https://github.com/SRCF/docs)!
+{{< closing_remarks >}}
 
 {{< alert type="info" >}}
 This tutorial was based largely on content provided to us by Matthew

--- a/content/tutorials/others/simple-minecraft-server.md
+++ b/content/tutorials/others/simple-minecraft-server.md
@@ -141,13 +141,14 @@ To learn more about running systemd services with the SRCF see
   
 Now that the setup is finished you can log out of doom.srcf.net using `logout`.
 
-{{ < alert type="warning" > }}
+{{< alert type="warning" >}}
 
 You may notice that in the command to start the server the memory it can use is limited to 1GB and its priority is set
 using `nice`. Please do not change the priority or memory usage of your server in order to be considerate to other
 users of the SRCF's systems!
 
-{{ < /alert > }}
+{{< /alert >}}
+
 ## Closing remarks
 
 Did you like this or find this cool? We invite you to check out

--- a/content/tutorials/others/simple-minecraft-server.md
+++ b/content/tutorials/others/simple-minecraft-server.md
@@ -151,10 +151,4 @@ users of the SRCF's systems!
 
 ## Closing remarks
 
-Did you like this or find this cool? We invite you to check out
-[more tutorials]({{< relref "/tutorials" >}})
-or [get in touch]({{< relref "/#help-and-support" >}}) to tell us what you thought!
-
-If you have any suggestions for how we could improve this documentation
-please send us an email at `support@srcf.net` or submit a Pull Request
-on [GitHub](https://github.com/SRCF/docs)!
+{{< closing_remarks >}}

--- a/content/tutorials/others/virtual-desktops-over-vnc.md
+++ b/content/tutorials/others/virtual-desktops-over-vnc.md
@@ -137,3 +137,7 @@ Replace `:12` with the **port number** for your VNC server.
 
 Make sure to close any running programs over VNC beforehand, as this
 will forcefully kill them too.
+
+## Closing remarks
+
+{{< closing_remarks >}}

--- a/content/tutorials/shell-and-files/logging-in.md
+++ b/content/tutorials/shell-and-files/logging-in.md
@@ -9,7 +9,7 @@ highlight: true
 
 ## Overview
 
-Just as a butterfly emerges from its coccoon to explore the great
+Just as a butterfly emerges from its cocoon to explore the great
 wonders of the world, you, too, will also uncover the great wonders of
 Linux with the SRCF by your side. In this tutorial, we'll show you how
 to log in to a UNIX-like shell and use the basics of the command line.
@@ -72,7 +72,7 @@ out in your home directory once you log in. The absolute path is
 you may have already discovered `ls` stands for list! You can pass in
 additional flags to change its output: `ls -la`.
 
-Now, try runnng `pwd`. This stands for *print working directory*. Think
+Now, try running `pwd`. This stands for *print working directory*. Think
 of this as a street sign. Right now, you're somewhere in the middle of
 complex and multi-layered file system on our shell server, which happens
 to be your home directory. `pwd` tells you where you are in this

--- a/content/tutorials/shell-and-files/logging-in.md
+++ b/content/tutorials/shell-and-files/logging-in.md
@@ -110,10 +110,4 @@ If you're interested in what else you can do with the shell, check out [our more
 
 ## Closing remarks
 
-Did you like this or find this cool? We invite you to check out
-[more tutorials]({{< relref "/tutorials" >}})
-or [get in touch]({{< relref "/#help-and-support" >}}) to tell us what you thought!
-
-If you have any suggestions for how we could improve this documentation
-please send us an email at `support@srcf.net` or submit a Pull Request
-on [GitHub](https://github.com/SRCF/docs)!
+{{< closing_remarks >}}

--- a/content/tutorials/shell-and-files/passwordless-login.md
+++ b/content/tutorials/shell-and-files/passwordless-login.md
@@ -78,10 +78,4 @@ You can even make this process simpler by [setting up an SSH configuration file]
 
 ## Closing remarks
 
-Did you like this or find this cool? We invite you to check out
-[more tutorials]({{< relref "/tutorials" >}})
-or [get in touch]({{< relref "/#help-and-support" >}}) to tell us what you thought!
-
-If you have any suggestions for how we could improve this documentation
-please send us an email at `support@srcf.net` or submit a Pull Request
-on [GitHub](https://github.com/SRCF/docs)!
+{{< closing_remarks >}}

--- a/content/tutorials/shell-and-files/terminal-guide.md
+++ b/content/tutorials/shell-and-files/terminal-guide.md
@@ -83,9 +83,9 @@ command. Use the arrow keys to scroll through the man text and press
 
 All files stored on the system reside in *directories* (this is the
 equivalent of Windows folders). The directories are arranged in a
-hierachical structure - directories may contain subdirectories and so
+hierarchical structure - directories may contain subdirectories and so
 on. The top of the hierarchy is called the *root directory*, and is
-represented by `/`. Other directories are refered to by their *path*,
+represented by `/`. Other directories are referred to by their *path*,
 for example, `/home/abc45/` represents the directory `abc45` which is a
 subdirectory of 'home', which in turn is a subdirectory of the root
 directory.
@@ -103,8 +103,8 @@ directory 'my\_dir', which is a subdirectory of the working directory.
 
 Filenames given without a preceding path are assumed to be in the
 working directory. All directories have a special subdirectory called
-`..` which refers to the directory one level higher up in the hierachy
-(the *parent direcvtory*), so `../some_file.txt` is the file
+`..` which refers to the directory one level higher up in the hierarchy
+(the *parent directory*), so `../some_file.txt` is the file
 `some_file.txt` in the parent directory of the working directory.
 
 To find out your current directory, use the command `pwd`:

--- a/content/tutorials/shell-and-files/terminal-guide.md
+++ b/content/tutorials/shell-and-files/terminal-guide.md
@@ -188,10 +188,4 @@ To log out of the system, type 'exit' at the command prompt.
 
 ## Closing remarks
 
-Did you like this or find this cool? We invite you to check out
-[more tutorials]({{< relref "/tutorials" >}})
-or [get in touch]({{< relref "/#help-and-support" >}}) to tell us what you thought!
-
-If you have any suggestions for how we could improve this documentation
-please send us an email at `support@srcf.net` or submit a Pull Request
-on [GitHub](https://github.com/SRCF/docs)!
+{{< closing_remarks >}}

--- a/content/tutorials/shell-and-files/uploading-files.md
+++ b/content/tutorials/shell-and-files/uploading-files.md
@@ -78,10 +78,4 @@ site and that site being published on the web. Please be patient.
 
 ## Closing remarks
 
-Did you like this or find this cool? We invite you to check out
-[more tutorials]({{< relref "/tutorials" >}})
-or [get in touch]({{< relref "/#help-and-support" >}}) to tell us what you thought!
-
-If you have any suggestions for how we could improve this documentation
-please send us an email at `support@srcf.net` or submit a Pull Request
-on [GitHub](https://github.com/SRCF/docs)!
+{{< closing_remarks >}}

--- a/content/tutorials/websites/deploy-a-web-app.md
+++ b/content/tutorials/websites/deploy-a-web-app.md
@@ -432,10 +432,4 @@ this in the [reference for web apps]({{< relref "/reference/web-hosting/web-appl
 
 ## Closing remarks
 
-Did you like this or find this cool? We invite you to check out
-[more tutorials]({{< relref "/tutorials" >}})
-or [get in touch]({{< relref "/#help-and-support" >}}) to tell us what you thought!
-
-If you have any suggestions for how we could improve this documentation
-please send us an email at `support@srcf.net` or submit a Pull Request
-on [GitHub](https://github.com/SRCF/docs)!
+{{< closing_remarks >}}

--- a/content/tutorials/websites/deploy-a-web-app.md
+++ b/content/tutorials/websites/deploy-a-web-app.md
@@ -224,7 +224,7 @@ end
 ```
 
 You can then run this by typing `ruby myapp.rb` and going to
-<http://localhost:4567> in your web browser. For futher information See
+<http://localhost:4567> in your web browser. For further information See
 the [Sinatra documentation](http://sinatrarb.com/intro.html).
 
 ### Express
@@ -384,7 +384,7 @@ crashes. We highly recommend using `systemd` to supervise your app.
     You will want to make your app write to a log file rather than stdout
     or stderr.
 
-We have further more general reading [on `systemd` services]({{< relref "/reference/shell-and-files/scheduled-tasks#systemd" >}}).
+We have more general reading [on `systemd` services]({{< relref "/reference/shell-and-files/scheduled-tasks#systemd" >}}).
 
 ### Notes for Python
 

--- a/content/tutorials/websites/static-site-generators.md
+++ b/content/tutorials/websites/static-site-generators.md
@@ -22,6 +22,4 @@ A few reputable SSGs out there include:
 
 ## Closing remarks
 
-Did you like this or find this cool? We invite you to check out [more tutorials]({{< relref "/tutorials" >}}) or [get in touch]({{< relref "/#help-and-support" >}}) to tell us what you thought!
-
-If you have any suggestions for how we could improve this documentation please send us an email at `support@srcf.net` or submit a Pull Request on [GitHub](https://github.com/SRCF/docs)!
+{{< closing_remarks >}}

--- a/content/tutorials/websites/wordpress-from-scratch.md
+++ b/content/tutorials/websites/wordpress-from-scratch.md
@@ -177,13 +177,7 @@ access it by following
 
 ## Closing remarks
 
-Did you like this or find this cool? We invite you to check out
-[more tutorials]({{< relref "/tutorials" >}})
-or [get in touch]({{< relref "/#help-and-support" >}}) to tell us what you thought!
-
-If you have any suggestions for how we could improve this documentation
-please send us an email at `support@srcf.net` or submit a Pull Request
-on [GitHub](https://github.com/SRCF/docs)!
+{{< closing_remarks >}}
 
 A big thanks to [Phil Ewels](https://phil.ewels.co.uk/) for writing this
 on his own blog and to hmw26 for some of their tips. This tutorial

--- a/content/tutorials/websites/wordpress-from-scratch.md
+++ b/content/tutorials/websites/wordpress-from-scratch.md
@@ -71,7 +71,7 @@ You can do this alternatively in the terminal by typing
 ## Configure WordPress
 
 Great! Now if you head to your website in a browser
-`https://**crsid**.user.srcf.net` for an indvidual account or
+`https://**crsid**.user.srcf.net` for an individual account or
 `https://**groupname**.soc.srcf.net` for a group account) you should see
 a friendly welcome screen. Fill in all of the details that it asks for -
 leave `localhost` as it is, try not to use `wp_` as the database prefix

--- a/layouts/shortcodes/closing_remarks.html
+++ b/layouts/shortcodes/closing_remarks.html
@@ -1,0 +1,11 @@
+<p>
+  Did you like this or find this cool? We invite you to check out
+  <a href="/tutorials/">more tutorials</a> or
+  <a href="/#help-and-support">get in touch</a> to tell us what
+  you thought!
+</p>
+<p>
+  If you have any suggestions for how we could improve this documentation
+  please send us an email at <code>support@srcf.net</code> or submit
+  a Pull Request on <a href="https://github.com/SRCF/docs">GitHub</a>!
+</p>


### PR DESCRIPTION
- Fix a bunch of typos
- Add a shortcode for the repeated "Closing remarks" section in `content/tutorials`.
- Fix a broken `alert` shortcode in `simple-minecraft-tutorial.md`